### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/build_id.py
+++ b/build_id.py
@@ -1,14 +1,14 @@
+from __future__ import print_function
 import datetime
 import sys
 import json
-json_data=open('./package.json').read();
+json_data=open('./package.json').read()
 data=json.loads(json_data)
-print 'release.version='+data['version']
-print 'ptf.version=0'
-print 'patch.level=0'
+print('release.version='+data['version'])
+print('ptf.version=0')
+print('patch.level=0')
 
 if len(sys.argv) > 1:
-  print 'build.level='+sys.argv[1]
+  print('build.level='+sys.argv[1])
 else:
-  print 'build.level='+(datetime.datetime.now().strftime('%Y%m%d%H%M'))
-
+  print('build.level='+datetime.datetime.now().strftime('%Y%m%d%H%M'))


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.