### PR TITLE
Updated vulnerable dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,8132 @@
+{
+    "name": "ibmapm-restclient",
+    "version": "19.6.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@babel/code-frame": {
+            "version": "7.5.5",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/@babel/code-frame/-/code-frame-7.5.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fcode-frame%2F-%2Fcode-frame-7.5.5.tgz",
+            "integrity": "sha1-vAeC9tafe31JUxIZaZuYj2aaj50=",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "^7.0.0"
+            }
+        },
+        "@babel/generator": {
+            "version": "7.5.5",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/@babel/generator/-/generator-7.5.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fgenerator%2F-%2Fgenerator-7.5.5.tgz",
+            "integrity": "sha1-hzp/k2o8iUkbQ1NtEiRbYmZk488=",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.5.5",
+                "jsesc": "^2.5.1",
+                "lodash": "^4.17.13",
+                "source-map": "^0.5.0",
+                "trim-right": "^1.0.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/source-map/-/source-map-0.5.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsource-map%2F-%2Fsource-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-function-name": {
+            "version": "7.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fhelper-function-name%2F-%2Fhelper-function-name-7.1.0.tgz",
+            "integrity": "sha1-oM6wFoX3M1XUNgwSR/WCv6/I/1M=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/template": "^7.1.0",
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-get-function-arity": {
+            "version": "7.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fhelper-get-function-arity%2F-%2Fhelper-get-function-arity-7.0.0.tgz",
+            "integrity": "sha1-g1ctQyDipGVyY3NBE8QoaLZOScM=",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.0.0"
+            }
+        },
+        "@babel/helper-split-export-declaration": {
+            "version": "7.4.4",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fhelper-split-export-declaration%2F-%2Fhelper-split-export-declaration-7.4.4.tgz",
+            "integrity": "sha1-/5SJSjQL549T8GrwOLIFxJ2ZNnc=",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.4.4"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.5.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/@babel/highlight/-/highlight-7.5.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fhighlight%2F-%2Fhighlight-7.5.0.tgz",
+            "integrity": "sha1-VtETEr2SSPphlZHQJHK+boyzJUA=",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/ansi-styles/-/ansi-styles-3.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-styles%2F-%2Fansi-styles-3.2.1.tgz",
+                    "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/chalk/-/chalk-2.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fchalk%2F-%2Fchalk-2.4.2.tgz",
+                    "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/has-flag/-/has-flag-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhas-flag%2F-%2Fhas-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "js-tokens": {
+                    "version": "4.0.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/js-tokens/-/js-tokens-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjs-tokens%2F-%2Fjs-tokens-4.0.0.tgz",
+                    "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/supports-color/-/supports-color-5.5.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsupports-color%2F-%2Fsupports-color-5.5.0.tgz",
+                    "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/parser": {
+            "version": "7.5.5",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/@babel/parser/-/parser-7.5.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fparser%2F-%2Fparser-7.5.5.tgz",
+            "integrity": "sha1-AvB3rIgX099Kgy71neZ1Zeccyks=",
+            "dev": true
+        },
+        "@babel/runtime": {
+            "version": "7.5.5",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/@babel/runtime/-/runtime-7.5.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fruntime%2F-%2Fruntime-7.5.5.tgz",
+            "integrity": "sha1-dPulbTXvvspEQJHHhQzNSU/S8TI=",
+            "dev": true,
+            "requires": {
+                "regenerator-runtime": "^0.13.2"
+            },
+            "dependencies": {
+                "regenerator-runtime": {
+                    "version": "0.13.3",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fregenerator-runtime%2F-%2Fregenerator-runtime-0.13.3.tgz",
+                    "integrity": "sha1-fPanfY9cb2Drc8X8GVWyzrAea/U=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/template": {
+            "version": "7.4.4",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/@babel/template/-/template-7.4.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Ftemplate%2F-%2Ftemplate-7.4.4.tgz",
+            "integrity": "sha1-9LiNEiVomgj1vDoXSDVFvp5O0jc=",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.4.4",
+                "@babel/types": "^7.4.4"
+            }
+        },
+        "@babel/traverse": {
+            "version": "7.5.5",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/@babel/traverse/-/traverse-7.5.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Ftraverse%2F-%2Ftraverse-7.5.5.tgz",
+            "integrity": "sha1-9mT482jtMpiM1kjan3LVynDxZbs=",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.5.5",
+                "@babel/generator": "^7.5.5",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.4.4",
+                "@babel/parser": "^7.5.5",
+                "@babel/types": "^7.5.5",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.13"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/debug/-/debug-4.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdebug%2F-%2Fdebug-4.1.1.tgz",
+                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                }
+            }
+        },
+        "@babel/types": {
+            "version": "7.5.5",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/@babel/types/-/types-7.5.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Ftypes%2F-%2Ftypes-7.5.5.tgz",
+            "integrity": "sha1-l7n3KOGCeFkJqkq1YmTwkKAo0Yo=",
+            "dev": true,
+            "requires": {
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.13",
+                "to-fast-properties": "^2.0.0"
+            }
+        },
+        "@kubernetes/client-node": {
+            "version": "0.10.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/@kubernetes/client-node/-/client-node-0.10.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40kubernetes%2Fclient-node%2F-%2Fclient-node-0.10.2.tgz",
+            "integrity": "sha1-nKnWBRSHdMf9dzRtc3Q+WGn5IFs=",
+            "requires": {
+                "@types/js-yaml": "^3.12.1",
+                "@types/node": "^10.12.0",
+                "@types/request": "^2.47.1",
+                "@types/underscore": "^1.8.9",
+                "@types/ws": "^6.0.1",
+                "isomorphic-ws": "^4.0.1",
+                "js-yaml": "^3.13.1",
+                "json-stream": "^1.0.0",
+                "jsonpath-plus": "^0.19.0",
+                "request": "^2.88.0",
+                "shelljs": "^0.8.2",
+                "tslib": "^1.9.3",
+                "underscore": "^1.9.1",
+                "ws": "^6.1.0"
+            },
+            "dependencies": {
+                "ws": {
+                    "version": "6.2.1",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/ws/-/ws-6.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fws%2F-%2Fws-6.2.1.tgz",
+                    "integrity": "sha1-RC/fCkftZPWbal2P8TD0dI7VJPs=",
+                    "requires": {
+                        "async-limiter": "~1.0.0"
+                    }
+                }
+            }
+        },
+        "@sindresorhus/is": {
+            "version": "0.7.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/@sindresorhus/is/-/is-0.7.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40sindresorhus%2Fis%2F-%2Fis-0.7.0.tgz",
+            "integrity": "sha1-mgb08TfuhNffBGDB/bETX/psUP0="
+        },
+        "@types/caseless": {
+            "version": "0.12.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/@types/caseless/-/caseless-0.12.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fcaseless%2F-%2Fcaseless-0.12.2.tgz",
+            "integrity": "sha1-9l09Y4ngHutFi9VNyPUrlalGO8g="
+        },
+        "@types/js-yaml": {
+            "version": "3.12.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/@types/js-yaml/-/js-yaml-3.12.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fjs-yaml%2F-%2Fjs-yaml-3.12.1.tgz",
+            "integrity": "sha1-XG9KHqvKhHkvvZFvDLQIR/EjxlY="
+        },
+        "@types/node": {
+            "version": "10.14.17",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/@types/node/-/node-10.14.17.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fnode%2F-%2Fnode-10.14.17.tgz",
+            "integrity": "sha1-uW1N0+QnOCSChIlIBB03VNQP1c4="
+        },
+        "@types/request": {
+            "version": "2.48.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/@types/request/-/request-2.48.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Frequest%2F-%2Frequest-2.48.2.tgz",
+            "integrity": "sha1-k2N0y+EXnX7VKfwCVD3rRZdFD+0=",
+            "requires": {
+                "@types/caseless": "*",
+                "@types/node": "*",
+                "@types/tough-cookie": "*",
+                "form-data": "^2.5.0"
+            }
+        },
+        "@types/tough-cookie": {
+            "version": "2.3.5",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/@types/tough-cookie/-/tough-cookie-2.3.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Ftough-cookie%2F-%2Ftough-cookie-2.3.5.tgz",
+            "integrity": "sha1-naRO11VxmZtlw3tgybK4jbVMWF0="
+        },
+        "@types/underscore": {
+            "version": "1.9.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/@types/underscore/-/underscore-1.9.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Funderscore%2F-%2Funderscore-1.9.2.tgz",
+            "integrity": "sha1-LE93QyhyGPXC2ag9s4BmcqpIUw0="
+        },
+        "@types/ws": {
+            "version": "6.0.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/@types/ws/-/ws-6.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fws%2F-%2Fws-6.0.3.tgz",
+            "integrity": "sha1-t3I3W6WdeQZlYcjYdQAUTWdLprM=",
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "acorn": {
+            "version": "7.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/acorn/-/acorn-7.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Facorn%2F-%2Facorn-7.0.0.tgz",
+            "integrity": "sha1-JrjRzZqbcANQtxwJBVRvZNEoTno=",
+            "dev": true
+        },
+        "acorn-jsx": {
+            "version": "5.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/acorn-jsx/-/acorn-jsx-5.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Facorn-jsx%2F-%2Facorn-jsx-5.0.2.tgz",
+            "integrity": "sha1-hLaOpEs3PE+GhgI6VR9hoht8Sk8=",
+            "dev": true
+        },
+        "agent-base": {
+            "version": "4.3.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/agent-base/-/agent-base-4.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fagent-base%2F-%2Fagent-base-4.3.0.tgz",
+            "integrity": "sha1-gWXwHENgCbzK0LHRIvBe13Dvxu4=",
+            "requires": {
+                "es6-promisify": "^5.0.0"
+            }
+        },
+        "aggregate-error": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/aggregate-error/-/aggregate-error-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Faggregate-error%2F-%2Faggregate-error-1.0.0.tgz",
+            "integrity": "sha1-iINE2tAiCnLjr1CQYRf0h3GSX6w=",
+            "requires": {
+                "clean-stack": "^1.0.0",
+                "indent-string": "^3.0.0"
+            }
+        },
+        "ajv": {
+            "version": "6.10.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/ajv/-/ajv-6.10.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fajv%2F-%2Fajv-6.10.2.tgz",
+            "integrity": "sha1-086gTWsBeyiUrWkED+yLYj60vVI=",
+            "requires": {
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            }
+        },
+        "ansi-escapes": {
+            "version": "3.2.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/ansi-escapes/-/ansi-escapes-3.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-escapes%2F-%2Fansi-escapes-3.2.0.tgz",
+            "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s=",
+            "dev": true
+        },
+        "ansi-regex": {
+            "version": "3.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/ansi-regex/-/ansi-regex-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-regex%2F-%2Fansi-regex-3.0.0.tgz",
+            "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/ansi-styles/-/ansi-styles-3.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-styles%2F-%2Fansi-styles-3.2.1.tgz",
+            "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+            "dev": true,
+            "requires": {
+                "color-convert": "^1.9.0"
+            }
+        },
+        "anymatch": {
+            "version": "3.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/anymatch/-/anymatch-3.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fanymatch%2F-%2Fanymatch-3.1.0.tgz",
+            "integrity": "sha1-5gk1DlCpMTtHJ4my8U7zWAjuFNY=",
+            "dev": true,
+            "requires": {
+                "normalize-path": "^3.0.0",
+                "picomatch": "^2.0.4"
+            }
+        },
+        "append-transform": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/append-transform/-/append-transform-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fappend-transform%2F-%2Fappend-transform-1.0.0.tgz",
+            "integrity": "sha1-BGpSrlgqIovXL1is++KWfGeHWas=",
+            "dev": true,
+            "requires": {
+                "default-require-extensions": "^2.0.0"
+            }
+        },
+        "archy": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/archy/-/archy-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Farchy%2F-%2Farchy-1.0.0.tgz",
+            "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+            "dev": true
+        },
+        "arg": {
+            "version": "4.1.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/arg/-/arg-4.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Farg%2F-%2Farg-4.1.1.tgz",
+            "integrity": "sha1-SF+OfDkM5MX3glfb6oDUvhH+2kw=",
+            "dev": true
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/argparse/-/argparse-1.0.10.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fargparse%2F-%2Fargparse-1.0.10.tgz",
+            "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "arr-union": {
+            "version": "3.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/arr-union/-/arr-union-3.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Farr-union%2F-%2Farr-union-3.1.0.tgz",
+            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+        },
+        "array-changes": {
+            "version": "3.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/array-changes/-/array-changes-3.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Farray-changes%2F-%2Farray-changes-3.0.1.tgz",
+            "integrity": "sha1-aRqrTrn8auQARG8bAlfNsP3TXdY=",
+            "dev": true,
+            "requires": {
+                "arraydiff-papandreou": "0.1.1-patch1"
+            }
+        },
+        "array-changes-async": {
+            "version": "3.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/array-changes-async/-/array-changes-async-3.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Farray-changes-async%2F-%2Farray-changes-async-3.0.1.tgz",
+            "integrity": "sha1-cQOWKunZVL4S4/DYROGscCH2Vog=",
+            "dev": true,
+            "requires": {
+                "arraydiff-async": "0.2.0"
+            }
+        },
+        "arraydiff-async": {
+            "version": "0.2.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/arraydiff-async/-/arraydiff-async-0.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Farraydiff-async%2F-%2Farraydiff-async-0.2.0.tgz",
+            "integrity": "sha1-uwUouY6BS3AvAfSWvHO+w+V/QIY=",
+            "dev": true
+        },
+        "arraydiff-papandreou": {
+            "version": "0.1.1-patch1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/arraydiff-papandreou/-/arraydiff-papandreou-0.1.1-patch1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Farraydiff-papandreou%2F-%2Farraydiff-papandreou-0.1.1-patch1.tgz",
+            "integrity": "sha1-ApAnC/27Sy762LdIJjitWnIQkhA=",
+            "dev": true
+        },
+        "asn1": {
+            "version": "0.2.4",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/asn1/-/asn1-0.2.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fasn1%2F-%2Fasn1-0.2.4.tgz",
+            "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
+            "requires": {
+                "safer-buffer": "~2.1.0"
+            }
+        },
+        "assert-plus": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/assert-plus/-/assert-plus-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fassert-plus%2F-%2Fassert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "assertion-error": {
+            "version": "1.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/assertion-error/-/assertion-error-1.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fassertion-error%2F-%2Fassertion-error-1.1.0.tgz",
+            "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
+            "dev": true
+        },
+        "astral-regex": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/astral-regex/-/astral-regex-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fastral-regex%2F-%2Fastral-regex-1.0.0.tgz",
+            "integrity": "sha1-bIw/uCfdQ+45GPJ7gngqt2WKb9k=",
+            "dev": true
+        },
+        "async": {
+            "version": "0.9.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/async/-/async-0.9.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fasync%2F-%2Fasync-0.9.2.tgz",
+            "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+            "dev": true
+        },
+        "async-hook-domain": {
+            "version": "1.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/async-hook-domain/-/async-hook-domain-1.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fasync-hook-domain%2F-%2Fasync-hook-domain-1.1.0.tgz",
+            "integrity": "sha1-doVeVyQlwr0fcXH5ib1A1w8S+dY=",
+            "dev": true,
+            "requires": {
+                "source-map-support": "^0.5.11"
+            }
+        },
+        "async-limiter": {
+            "version": "1.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/async-limiter/-/async-limiter-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fasync-limiter%2F-%2Fasync-limiter-1.0.1.tgz",
+            "integrity": "sha1-3TeelPDbgxCwgpH51kwyCXZmF/0="
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/asynckit/-/asynckit-0.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fasynckit%2F-%2Fasynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+        },
+        "aws-sign2": {
+            "version": "0.7.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/aws-sign2/-/aws-sign2-0.7.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Faws-sign2%2F-%2Faws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+        },
+        "aws4": {
+            "version": "1.8.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/aws4/-/aws4-1.8.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Faws4%2F-%2Faws4-1.8.0.tgz",
+            "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8="
+        },
+        "babel-runtime": {
+            "version": "6.26.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/babel-runtime/-/babel-runtime-6.26.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbabel-runtime%2F-%2Fbabel-runtime-6.26.0.tgz",
+            "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+            "dev": true,
+            "requires": {
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
+            }
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/balanced-match/-/balanced-match-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbalanced-match%2F-%2Fbalanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+        },
+        "base64url": {
+            "version": "3.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/base64url/-/base64url-3.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbase64url%2F-%2Fbase64url-3.0.1.tgz",
+            "integrity": "sha1-Y5nVcuK8P5CpqLItXbsKMtM/eI0="
+        },
+        "bcrypt-pbkdf": {
+            "version": "1.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbcrypt-pbkdf%2F-%2Fbcrypt-pbkdf-1.0.2.tgz",
+            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+            "requires": {
+                "tweetnacl": "^0.14.3"
+            }
+        },
+        "binary-extensions": {
+            "version": "2.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/binary-extensions/-/binary-extensions-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbinary-extensions%2F-%2Fbinary-extensions-2.0.0.tgz",
+            "integrity": "sha1-I8DfFPaogHf1+YbA0WfsA8PVU3w=",
+            "dev": true
+        },
+        "bind-obj-methods": {
+            "version": "2.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/bind-obj-methods/-/bind-obj-methods-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbind-obj-methods%2F-%2Fbind-obj-methods-2.0.0.tgz",
+            "integrity": "sha1-AXgUDb57e7Z9x0iSrOWbwCR/BvA=",
+            "dev": true
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/brace-expansion/-/brace-expansion-1.1.11.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbrace-expansion%2F-%2Fbrace-expansion-1.1.11.tgz",
+            "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "braces": {
+            "version": "3.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/braces/-/braces-3.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbraces%2F-%2Fbraces-3.0.2.tgz",
+            "integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
+            "dev": true,
+            "requires": {
+                "fill-range": "^7.0.1"
+            }
+        },
+        "browser-process-hrtime": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbrowser-process-hrtime%2F-%2Fbrowser-process-hrtime-1.0.0.tgz",
+            "integrity": "sha1-PJtLfXgsgSHlbxAQbYTA0P/JRiY=",
+            "dev": true
+        },
+        "browser-stdout": {
+            "version": "1.3.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/browser-stdout/-/browser-stdout-1.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbrowser-stdout%2F-%2Fbrowser-stdout-1.3.0.tgz",
+            "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+            "dev": true
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/buffer-from/-/buffer-from-1.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbuffer-from%2F-%2Fbuffer-from-1.1.1.tgz",
+            "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
+            "dev": true
+        },
+        "buffer-shims": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/buffer-shims/-/buffer-shims-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fbuffer-shims%2F-%2Fbuffer-shims-1.0.0.tgz",
+            "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+            "dev": true
+        },
+        "cacheable-request": {
+            "version": "2.1.4",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/cacheable-request/-/cacheable-request-2.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcacheable-request%2F-%2Fcacheable-request-2.1.4.tgz",
+            "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
+            "requires": {
+                "clone-response": "1.0.2",
+                "get-stream": "3.0.0",
+                "http-cache-semantics": "3.8.1",
+                "keyv": "3.0.0",
+                "lowercase-keys": "1.0.0",
+                "normalize-url": "2.0.1",
+                "responselike": "1.0.2"
+            },
+            "dependencies": {
+                "lowercase-keys": {
+                    "version": "1.0.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/lowercase-keys/-/lowercase-keys-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flowercase-keys%2F-%2Flowercase-keys-1.0.0.tgz",
+                    "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+                }
+            }
+        },
+        "caching-transform": {
+            "version": "3.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/caching-transform/-/caching-transform-3.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcaching-transform%2F-%2Fcaching-transform-3.0.2.tgz",
+            "integrity": "sha1-YB1GuR7Kh2h6KB5xzvmXkbDvynA=",
+            "dev": true,
+            "requires": {
+                "hasha": "^3.0.0",
+                "make-dir": "^2.0.0",
+                "package-hash": "^3.0.0",
+                "write-file-atomic": "^2.4.2"
+            },
+            "dependencies": {
+                "write-file-atomic": {
+                    "version": "2.4.3",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/write-file-atomic/-/write-file-atomic-2.4.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwrite-file-atomic%2F-%2Fwrite-file-atomic-2.4.3.tgz",
+                    "integrity": "sha1-H9Lprh3z51uNjDZ0Q8aS1MqB9IE=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.11",
+                        "imurmurhash": "^0.1.4",
+                        "signal-exit": "^3.0.2"
+                    }
+                }
+            }
+        },
+        "callsites": {
+            "version": "3.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/callsites/-/callsites-3.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcallsites%2F-%2Fcallsites-3.1.0.tgz",
+            "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=",
+            "dev": true
+        },
+        "camelcase": {
+            "version": "5.3.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/camelcase/-/camelcase-5.3.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcamelcase%2F-%2Fcamelcase-5.3.1.tgz",
+            "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA="
+        },
+        "capture-stack-trace": {
+            "version": "1.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcapture-stack-trace%2F-%2Fcapture-stack-trace-1.0.1.tgz",
+            "integrity": "sha1-psC74fOPOqC5Ijjstv9Cw0TUE10=",
+            "dev": true
+        },
+        "caseless": {
+            "version": "0.12.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/caseless/-/caseless-0.12.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcaseless%2F-%2Fcaseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+        },
+        "chai": {
+            "version": "3.5.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/chai/-/chai-3.5.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fchai%2F-%2Fchai-3.5.0.tgz",
+            "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+            "dev": true,
+            "requires": {
+                "assertion-error": "^1.0.1",
+                "deep-eql": "^0.1.3",
+                "type-detect": "^1.0.0"
+            }
+        },
+        "chalk": {
+            "version": "2.4.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/chalk/-/chalk-2.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fchalk%2F-%2Fchalk-2.4.2.tgz",
+            "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            }
+        },
+        "chardet": {
+            "version": "0.7.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/chardet/-/chardet-0.7.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fchardet%2F-%2Fchardet-0.7.0.tgz",
+            "integrity": "sha1-kAlISfCTfy7twkJdDSip5fDLrZ4=",
+            "dev": true
+        },
+        "charenc": {
+            "version": "0.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/charenc/-/charenc-0.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcharenc%2F-%2Fcharenc-0.0.2.tgz",
+            "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+            "dev": true
+        },
+        "chokidar": {
+            "version": "3.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/chokidar/-/chokidar-3.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fchokidar%2F-%2Fchokidar-3.0.2.tgz",
+            "integrity": "sha1-DRzW0E6y3wMnRGGIzRNzajNn1oE=",
+            "dev": true,
+            "requires": {
+                "anymatch": "^3.0.1",
+                "braces": "^3.0.2",
+                "fsevents": "^2.0.6",
+                "glob-parent": "^5.0.0",
+                "is-binary-path": "^2.1.0",
+                "is-glob": "^4.0.1",
+                "normalize-path": "^3.0.0",
+                "readdirp": "^3.1.1"
+            }
+        },
+        "clean-stack": {
+            "version": "1.3.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/clean-stack/-/clean-stack-1.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fclean-stack%2F-%2Fclean-stack-1.3.0.tgz",
+            "integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE="
+        },
+        "cli-cursor": {
+            "version": "2.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/cli-cursor/-/cli-cursor-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcli-cursor%2F-%2Fcli-cursor-2.1.0.tgz",
+            "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+            "dev": true,
+            "requires": {
+                "restore-cursor": "^2.0.0"
+            }
+        },
+        "cli-width": {
+            "version": "2.2.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/cli-width/-/cli-width-2.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcli-width%2F-%2Fcli-width-2.2.0.tgz",
+            "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+            "dev": true
+        },
+        "cliui": {
+            "version": "4.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/cliui/-/cliui-4.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcliui%2F-%2Fcliui-4.1.0.tgz",
+            "integrity": "sha1-NIQi2+gtgAswIu709qwQvy5NG0k=",
+            "dev": true,
+            "requires": {
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0",
+                "wrap-ansi": "^2.0.0"
+            }
+        },
+        "clone-deep": {
+            "version": "0.2.4",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/clone-deep/-/clone-deep-0.2.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fclone-deep%2F-%2Fclone-deep-0.2.4.tgz",
+            "integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
+            "requires": {
+                "for-own": "^0.1.3",
+                "is-plain-object": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "lazy-cache": "^1.0.3",
+                "shallow-clone": "^0.1.2"
+            }
+        },
+        "clone-response": {
+            "version": "1.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/clone-response/-/clone-response-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fclone-response%2F-%2Fclone-response-1.0.2.tgz",
+            "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+            "requires": {
+                "mimic-response": "^1.0.0"
+            }
+        },
+        "code-point-at": {
+            "version": "1.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/code-point-at/-/code-point-at-1.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcode-point-at%2F-%2Fcode-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "dev": true
+        },
+        "color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/color-convert/-/color-convert-1.9.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcolor-convert%2F-%2Fcolor-convert-1.9.3.tgz",
+            "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-diff": {
+            "version": "0.1.7",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/color-diff/-/color-diff-0.1.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcolor-diff%2F-%2Fcolor-diff-0.1.7.tgz",
+            "integrity": "sha1-bbeM2UgqjkWdQIIer0tQMoPcuOI=",
+            "dev": true
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/color-name/-/color-name-1.1.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcolor-name%2F-%2Fcolor-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "color-support": {
+            "version": "1.1.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/color-support/-/color-support-1.1.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcolor-support%2F-%2Fcolor-support-1.1.3.tgz",
+            "integrity": "sha1-k4NDeaHMmgxh+C9S8NBDIiUb1aI=",
+            "dev": true
+        },
+        "combined-stream": {
+            "version": "1.0.8",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/combined-stream/-/combined-stream-1.0.8.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcombined-stream%2F-%2Fcombined-stream-1.0.8.tgz",
+            "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
+            "requires": {
+                "delayed-stream": "~1.0.0"
+            }
+        },
+        "commander": {
+            "version": "2.9.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/commander/-/commander-2.9.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcommander%2F-%2Fcommander-2.9.0.tgz",
+            "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+            "dev": true,
+            "requires": {
+                "graceful-readlink": ">= 1.0.0"
+            }
+        },
+        "commondir": {
+            "version": "1.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/commondir/-/commondir-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcommondir%2F-%2Fcommondir-1.0.1.tgz",
+            "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/concat-map/-/concat-map-0.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fconcat-map%2F-%2Fconcat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "core-js": {
+            "version": "2.6.9",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/core-js/-/core-js-2.6.9.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcore-js%2F-%2Fcore-js-2.6.9.tgz",
+            "integrity": "sha1-a0shRiDINBUuF5Mjcn/Bl0GwhPI=",
+            "dev": true
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/core-util-is/-/core-util-is-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcore-util-is%2F-%2Fcore-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "coveralls": {
+            "version": "3.0.6",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/coveralls/-/coveralls-3.0.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcoveralls%2F-%2Fcoveralls-3.0.6.tgz",
+            "integrity": "sha1-XGOydZtngRGOdDm9hwul6e5CiyU=",
+            "dev": true,
+            "requires": {
+                "growl": "~> 1.10.0",
+                "js-yaml": "^3.13.1",
+                "lcov-parse": "^0.0.10",
+                "log-driver": "^1.2.7",
+                "minimist": "^1.2.0",
+                "request": "^2.86.0"
+            }
+        },
+        "cp-file": {
+            "version": "6.2.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/cp-file/-/cp-file-6.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcp-file%2F-%2Fcp-file-6.2.0.tgz",
+            "integrity": "sha1-QNXqSh3vKprN0HulwLAkbvc9wQ0=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "make-dir": "^2.0.0",
+                "nested-error-stacks": "^2.0.0",
+                "pify": "^4.0.1",
+                "safe-buffer": "^5.0.1"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/pify/-/pify-4.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpify%2F-%2Fpify-4.0.1.tgz",
+                    "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+                    "dev": true
+                }
+            }
+        },
+        "cross-spawn": {
+            "version": "4.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/cross-spawn/-/cross-spawn-4.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcross-spawn%2F-%2Fcross-spawn-4.0.2.tgz",
+            "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+            "dev": true,
+            "requires": {
+                "lru-cache": "^4.0.1",
+                "which": "^1.2.9"
+            },
+            "dependencies": {
+                "lru-cache": {
+                    "version": "4.1.5",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/lru-cache/-/lru-cache-4.1.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flru-cache%2F-%2Flru-cache-4.1.5.tgz",
+                    "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
+                    "dev": true,
+                    "requires": {
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
+                    }
+                },
+                "yallist": {
+                    "version": "2.1.2",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/yallist/-/yallist-2.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fyallist%2F-%2Fyallist-2.1.2.tgz",
+                    "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+                    "dev": true
+                }
+            }
+        },
+        "crypt": {
+            "version": "0.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/crypt/-/crypt-0.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcrypt%2F-%2Fcrypt-0.0.2.tgz",
+            "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+            "dev": true
+        },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/dashdash/-/dashdash-1.14.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdashdash%2F-%2Fdashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "debug": {
+            "version": "3.2.6",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/debug/-/debug-3.2.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdebug%2F-%2Fdebug-3.2.6.tgz",
+            "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+            "requires": {
+                "ms": "^2.1.1"
+            }
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/decamelize/-/decamelize-1.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdecamelize%2F-%2Fdecamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
+        },
+        "decode-uri-component": {
+            "version": "0.2.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/decode-uri-component/-/decode-uri-component-0.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdecode-uri-component%2F-%2Fdecode-uri-component-0.2.0.tgz",
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+        },
+        "decompress-response": {
+            "version": "3.3.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/decompress-response/-/decompress-response-3.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdecompress-response%2F-%2Fdecompress-response-3.3.0.tgz",
+            "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+            "requires": {
+                "mimic-response": "^1.0.0"
+            }
+        },
+        "deep-eql": {
+            "version": "0.1.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/deep-eql/-/deep-eql-0.1.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdeep-eql%2F-%2Fdeep-eql-0.1.3.tgz",
+            "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+            "dev": true,
+            "requires": {
+                "type-detect": "0.1.1"
+            },
+            "dependencies": {
+                "type-detect": {
+                    "version": "0.1.1",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/type-detect/-/type-detect-0.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftype-detect%2F-%2Ftype-detect-0.1.1.tgz",
+                    "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+                    "dev": true
+                }
+            }
+        },
+        "deep-is": {
+            "version": "0.1.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/deep-is/-/deep-is-0.1.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdeep-is%2F-%2Fdeep-is-0.1.3.tgz",
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
+        },
+        "deepmerge": {
+            "version": "4.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/deepmerge/-/deepmerge-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdeepmerge%2F-%2Fdeepmerge-4.0.0.tgz",
+            "integrity": "sha1-PjEQyikgXxINfLBklgo5w9IIfAk="
+        },
+        "default-require-extensions": {
+            "version": "2.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/default-require-extensions/-/default-require-extensions-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdefault-require-extensions%2F-%2Fdefault-require-extensions-2.0.0.tgz",
+            "integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+            "dev": true,
+            "requires": {
+                "strip-bom": "^3.0.0"
+            }
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/delayed-stream/-/delayed-stream-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdelayed-stream%2F-%2Fdelayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+        },
+        "depd": {
+            "version": "2.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/depd/-/depd-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdepd%2F-%2Fdepd-2.0.0.tgz",
+            "integrity": "sha1-tpYWPMdXVg0JzyLMj60Vcbeedt8="
+        },
+        "detect-indent": {
+            "version": "3.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/detect-indent/-/detect-indent-3.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdetect-indent%2F-%2Fdetect-indent-3.0.1.tgz",
+            "integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
+            "dev": true,
+            "requires": {
+                "get-stdin": "^4.0.1",
+                "minimist": "^1.1.0",
+                "repeating": "^1.1.0"
+            }
+        },
+        "diff": {
+            "version": "3.2.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/diff/-/diff-3.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdiff%2F-%2Fdiff-3.2.0.tgz",
+            "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+            "dev": true
+        },
+        "doctrine": {
+            "version": "3.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/doctrine/-/doctrine-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdoctrine%2F-%2Fdoctrine-3.0.0.tgz",
+            "integrity": "sha1-rd6+rXKmV023g2OdyHoSF3OXOWE=",
+            "dev": true,
+            "requires": {
+                "esutils": "^2.0.2"
+            }
+        },
+        "duplexer2": {
+            "version": "0.1.4",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/duplexer2/-/duplexer2-0.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fduplexer2%2F-%2Fduplexer2-0.1.4.tgz",
+            "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.0.2"
+            }
+        },
+        "duplexer3": {
+            "version": "0.1.4",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/duplexer3/-/duplexer3-0.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fduplexer3%2F-%2Fduplexer3-0.1.4.tgz",
+            "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+        },
+        "ecc-jsbn": {
+            "version": "0.1.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fecc-jsbn%2F-%2Fecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+            "requires": {
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
+            }
+        },
+        "emoji-regex": {
+            "version": "7.0.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/emoji-regex/-/emoji-regex-7.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Femoji-regex%2F-%2Femoji-regex-7.0.3.tgz",
+            "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
+            "dev": true
+        },
+        "end-of-stream": {
+            "version": "1.4.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/end-of-stream/-/end-of-stream-1.4.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fend-of-stream%2F-%2Fend-of-stream-1.4.1.tgz",
+            "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
+            "requires": {
+                "once": "^1.4.0"
+            }
+        },
+        "error-ex": {
+            "version": "1.3.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/error-ex/-/error-ex-1.3.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ferror-ex%2F-%2Ferror-ex-1.3.2.tgz",
+            "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
+            "dev": true,
+            "requires": {
+                "is-arrayish": "^0.2.1"
+            }
+        },
+        "es6-error": {
+            "version": "4.1.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/es6-error/-/es6-error-4.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fes6-error%2F-%2Fes6-error-4.1.1.tgz",
+            "integrity": "sha1-njr0B0Wd7tR+mpH5uIWoTrBcVh0=",
+            "dev": true
+        },
+        "es6-promise": {
+            "version": "4.2.8",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/es6-promise/-/es6-promise-4.2.8.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fes6-promise%2F-%2Fes6-promise-4.2.8.tgz",
+            "integrity": "sha1-TrIVlMlyvEBVPSduUQU5FD21Pgo="
+        },
+        "es6-promisify": {
+            "version": "5.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/es6-promisify/-/es6-promisify-5.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fes6-promisify%2F-%2Fes6-promisify-5.0.0.tgz",
+            "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+            "requires": {
+                "es6-promise": "^4.0.3"
+            }
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fescape-string-regexp%2F-%2Fescape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "eslint": {
+            "version": "6.3.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/eslint/-/eslint-6.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint%2F-%2Feslint-6.3.0.tgz",
+            "integrity": "sha1-HxqQL2e/1MNU5yiLgeQGVNkn62o=",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "ajv": "^6.10.0",
+                "chalk": "^2.1.0",
+                "cross-spawn": "^6.0.5",
+                "debug": "^4.0.1",
+                "doctrine": "^3.0.0",
+                "eslint-scope": "^5.0.0",
+                "eslint-utils": "^1.4.2",
+                "eslint-visitor-keys": "^1.1.0",
+                "espree": "^6.1.1",
+                "esquery": "^1.0.1",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^5.0.1",
+                "functional-red-black-tree": "^1.0.1",
+                "glob-parent": "^5.0.0",
+                "globals": "^11.7.0",
+                "ignore": "^4.0.6",
+                "import-fresh": "^3.0.0",
+                "imurmurhash": "^0.1.4",
+                "inquirer": "^6.4.1",
+                "is-glob": "^4.0.0",
+                "js-yaml": "^3.13.1",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.3.0",
+                "lodash": "^4.17.14",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.1",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.8.2",
+                "progress": "^2.0.0",
+                "regexpp": "^2.0.1",
+                "semver": "^6.1.2",
+                "strip-ansi": "^5.2.0",
+                "strip-json-comments": "^3.0.1",
+                "table": "^5.2.3",
+                "text-table": "^0.2.0",
+                "v8-compile-cache": "^2.0.3"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/ansi-regex/-/ansi-regex-4.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-regex%2F-%2Fansi-regex-4.1.0.tgz",
+                    "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+                    "dev": true
+                },
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/cross-spawn/-/cross-spawn-6.0.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcross-spawn%2F-%2Fcross-spawn-6.0.5.tgz",
+                    "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    },
+                    "dependencies": {
+                        "semver": {
+                            "version": "5.7.1",
+                            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/semver/-/semver-5.7.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsemver%2F-%2Fsemver-5.7.1.tgz",
+                            "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+                            "dev": true
+                        }
+                    }
+                },
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/debug/-/debug-4.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdebug%2F-%2Fdebug-4.1.1.tgz",
+                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/semver/-/semver-6.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsemver%2F-%2Fsemver-6.3.0.tgz",
+                    "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/strip-ansi/-/strip-ansi-5.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstrip-ansi%2F-%2Fstrip-ansi-5.2.0.tgz",
+                    "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
+            }
+        },
+        "eslint-config-strongloop": {
+            "version": "2.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/eslint-config-strongloop/-/eslint-config-strongloop-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-config-strongloop%2F-%2Feslint-config-strongloop-2.1.0.tgz",
+            "integrity": "sha1-dj3Rmt/OiNewBR5uJV8a43eDtMY=",
+            "dev": true
+        },
+        "eslint-scope": {
+            "version": "5.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/eslint-scope/-/eslint-scope-5.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-scope%2F-%2Feslint-scope-5.0.0.tgz",
+            "integrity": "sha1-6HyIh8c+jR7ITxylkWRcNYv8j7k=",
+            "dev": true,
+            "requires": {
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
+            }
+        },
+        "eslint-utils": {
+            "version": "1.4.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/eslint-utils/-/eslint-utils-1.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-utils%2F-%2Feslint-utils-1.4.2.tgz",
+            "integrity": "sha1-FmpRgO9qt+tGLxYv0ObyRj1zCas=",
+            "dev": true,
+            "requires": {
+                "eslint-visitor-keys": "^1.0.0"
+            }
+        },
+        "eslint-visitor-keys": {
+            "version": "1.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-visitor-keys%2F-%2Feslint-visitor-keys-1.1.0.tgz",
+            "integrity": "sha1-4qgs6oT/JGrW+1f5veW0ZiFFnsI=",
+            "dev": true
+        },
+        "esm": {
+            "version": "3.2.25",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/esm/-/esm-3.2.25.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fesm%2F-%2Fesm-3.2.25.tgz",
+            "integrity": "sha1-NCwYwp1WFXaIulzjH4Qx+7eVzBA=",
+            "dev": true
+        },
+        "espree": {
+            "version": "6.1.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/espree/-/espree-6.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fespree%2F-%2Fespree-6.1.1.tgz",
+            "integrity": "sha1-f4Dl9yV/xH20UAItcj41ba6x5d4=",
+            "dev": true,
+            "requires": {
+                "acorn": "^7.0.0",
+                "acorn-jsx": "^5.0.2",
+                "eslint-visitor-keys": "^1.1.0"
+            }
+        },
+        "esprima": {
+            "version": "4.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/esprima/-/esprima-4.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fesprima%2F-%2Fesprima-4.0.1.tgz",
+            "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
+        },
+        "esquery": {
+            "version": "1.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/esquery/-/esquery-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fesquery%2F-%2Fesquery-1.0.1.tgz",
+            "integrity": "sha1-QGxRZYsfWZGl+bYrHcJbAOPlxwg=",
+            "dev": true,
+            "requires": {
+                "estraverse": "^4.0.0"
+            }
+        },
+        "esrecurse": {
+            "version": "4.2.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/esrecurse/-/esrecurse-4.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fesrecurse%2F-%2Fesrecurse-4.2.1.tgz",
+            "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
+            "dev": true,
+            "requires": {
+                "estraverse": "^4.1.0"
+            }
+        },
+        "estraverse": {
+            "version": "4.3.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/estraverse/-/estraverse-4.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Festraverse%2F-%2Festraverse-4.3.0.tgz",
+            "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/esutils/-/esutils-2.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fesutils%2F-%2Fesutils-2.0.3.tgz",
+            "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
+            "dev": true
+        },
+        "events-to-array": {
+            "version": "1.1.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/events-to-array/-/events-to-array-1.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fevents-to-array%2F-%2Fevents-to-array-1.1.2.tgz",
+            "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
+            "dev": true
+        },
+        "extend": {
+            "version": "3.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/extend/-/extend-3.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fextend%2F-%2Fextend-3.0.2.tgz",
+            "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
+        },
+        "external-editor": {
+            "version": "3.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/external-editor/-/external-editor-3.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fexternal-editor%2F-%2Fexternal-editor-3.1.0.tgz",
+            "integrity": "sha1-ywP3QL764D6k0oPK7SdBqD8zVJU=",
+            "dev": true,
+            "requires": {
+                "chardet": "^0.7.0",
+                "iconv-lite": "^0.4.24",
+                "tmp": "^0.0.33"
+            }
+        },
+        "extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/extsprintf/-/extsprintf-1.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fextsprintf%2F-%2Fextsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+        },
+        "fast-deep-equal": {
+            "version": "2.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffast-deep-equal%2F-%2Ffast-deep-equal-2.0.1.tgz",
+            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffast-json-stable-stringify%2F-%2Ffast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+        },
+        "fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffast-levenshtein%2F-%2Ffast-levenshtein-2.0.6.tgz",
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
+        },
+        "figures": {
+            "version": "2.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/figures/-/figures-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffigures%2F-%2Ffigures-2.0.0.tgz",
+            "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "^1.0.5"
+            }
+        },
+        "file-entry-cache": {
+            "version": "5.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/file-entry-cache/-/file-entry-cache-5.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffile-entry-cache%2F-%2Ffile-entry-cache-5.0.1.tgz",
+            "integrity": "sha1-yg9u+m3T1WEzP7FFFQZcL6/fQ5w=",
+            "dev": true,
+            "requires": {
+                "flat-cache": "^2.0.1"
+            }
+        },
+        "fill-range": {
+            "version": "7.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/fill-range/-/fill-range-7.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffill-range%2F-%2Ffill-range-7.0.1.tgz",
+            "integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
+            "dev": true,
+            "requires": {
+                "to-regex-range": "^5.0.1"
+            }
+        },
+        "find-cache-dir": {
+            "version": "2.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/find-cache-dir/-/find-cache-dir-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffind-cache-dir%2F-%2Ffind-cache-dir-2.1.0.tgz",
+            "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
+            "dev": true,
+            "requires": {
+                "commondir": "^1.0.1",
+                "make-dir": "^2.0.0",
+                "pkg-dir": "^3.0.0"
+            }
+        },
+        "find-up": {
+            "version": "3.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/find-up/-/find-up-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffind-up%2F-%2Ffind-up-3.0.0.tgz",
+            "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+            "dev": true,
+            "requires": {
+                "locate-path": "^3.0.0"
+            }
+        },
+        "findit": {
+            "version": "2.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/findit/-/findit-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffindit%2F-%2Ffindit-2.0.0.tgz",
+            "integrity": "sha1-ZQnwEmr0wXhVHPqZOU4DLhOk1W4=",
+            "dev": true
+        },
+        "flat-cache": {
+            "version": "2.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/flat-cache/-/flat-cache-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fflat-cache%2F-%2Fflat-cache-2.0.1.tgz",
+            "integrity": "sha1-XSltbwS9pEpGMKMBQTvbwuwIXsA=",
+            "dev": true,
+            "requires": {
+                "flatted": "^2.0.0",
+                "rimraf": "2.6.3",
+                "write": "1.0.3"
+            }
+        },
+        "flatted": {
+            "version": "2.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/flatted/-/flatted-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fflatted%2F-%2Fflatted-2.0.1.tgz",
+            "integrity": "sha1-aeV8qo8OrLwoHS4stFjUb9tEngg=",
+            "dev": true
+        },
+        "flow-parser": {
+            "version": "0.106.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/flow-parser/-/flow-parser-0.106.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fflow-parser%2F-%2Fflow-parser-0.106.3.tgz",
+            "integrity": "sha1-N9+3AlToveBTgI0AcR5Kk/cisq8=",
+            "dev": true
+        },
+        "flow-remove-types": {
+            "version": "2.106.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/flow-remove-types/-/flow-remove-types-2.106.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fflow-remove-types%2F-%2Fflow-remove-types-2.106.3.tgz",
+            "integrity": "sha1-dmrsviha7VhKefxH9r8Ssi/mW7o=",
+            "dev": true,
+            "requires": {
+                "flow-parser": "^0.106.3",
+                "pirates": "^3.0.2",
+                "vlq": "^0.2.1"
+            }
+        },
+        "for-in": {
+            "version": "1.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/for-in/-/for-in-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffor-in%2F-%2Ffor-in-1.0.2.tgz",
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+        },
+        "for-own": {
+            "version": "0.1.5",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/for-own/-/for-own-0.1.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffor-own%2F-%2Ffor-own-0.1.5.tgz",
+            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+            "requires": {
+                "for-in": "^1.0.1"
+            }
+        },
+        "foreground-child": {
+            "version": "1.5.6",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/foreground-child/-/foreground-child-1.5.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fforeground-child%2F-%2Fforeground-child-1.5.6.tgz",
+            "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+            "dev": true,
+            "requires": {
+                "cross-spawn": "^4",
+                "signal-exit": "^3.0.0"
+            }
+        },
+        "forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/forever-agent/-/forever-agent-0.6.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fforever-agent%2F-%2Fforever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+        },
+        "form-data": {
+            "version": "2.5.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/form-data/-/form-data-2.5.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fform-data%2F-%2Fform-data-2.5.1.tgz",
+            "integrity": "sha1-8svsV7XlniNxbhKP5E1OXdI4lfQ=",
+            "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
+            }
+        },
+        "from2": {
+            "version": "2.3.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/from2/-/from2-2.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffrom2%2F-%2Ffrom2-2.3.0.tgz",
+            "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+            "requires": {
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0"
+            }
+        },
+        "fs-exists-cached": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/fs-exists-cached/-/fs-exists-cached-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffs-exists-cached%2F-%2Ffs-exists-cached-1.0.0.tgz",
+            "integrity": "sha1-zyVVTKBQ3EmuZla0HeQiWJidy84=",
+            "dev": true
+        },
+        "fs-extra": {
+            "version": "6.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/fs-extra/-/fs-extra-6.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffs-extra%2F-%2Ffs-extra-6.0.0.tgz",
+            "integrity": "sha1-Dwr7KQuz3rh5eNqBb808d5fzqBc=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            }
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/fs.realpath/-/fs.realpath-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffs.realpath%2F-%2Ffs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+        },
+        "fsevents": {
+            "version": "2.0.7",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/fsevents/-/fsevents-2.0.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffsevents%2F-%2Ffsevents-2.0.7.tgz",
+            "integrity": "sha1-OCybRDxsusTFcYfN2iOqO/HM/Co=",
+            "dev": true,
+            "optional": true
+        },
+        "function-loop": {
+            "version": "1.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/function-loop/-/function-loop-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffunction-loop%2F-%2Ffunction-loop-1.0.2.tgz",
+            "integrity": "sha1-Frk911eEXqz+yhqAYaamXBBuDLI=",
+            "dev": true
+        },
+        "functional-red-black-tree": {
+            "version": "1.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffunctional-red-black-tree%2F-%2Ffunctional-red-black-tree-1.0.1.tgz",
+            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+            "dev": true
+        },
+        "get-caller-file": {
+            "version": "2.0.5",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/get-caller-file/-/get-caller-file-2.0.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fget-caller-file%2F-%2Fget-caller-file-2.0.5.tgz",
+            "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
+            "dev": true
+        },
+        "get-stdin": {
+            "version": "4.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/get-stdin/-/get-stdin-4.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fget-stdin%2F-%2Fget-stdin-4.0.1.tgz",
+            "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+            "dev": true
+        },
+        "get-stream": {
+            "version": "3.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/get-stream/-/get-stream-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fget-stream%2F-%2Fget-stream-3.0.0.tgz",
+            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+        },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/getpass/-/getpass-0.1.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fgetpass%2F-%2Fgetpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "requires": {
+                "assert-plus": "^1.0.0"
+            }
+        },
+        "glob": {
+            "version": "7.1.4",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/glob/-/glob-7.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fglob%2F-%2Fglob-7.1.4.tgz",
+            "integrity": "sha1-qmCKL2xXetNX4a5aXCbZqNGWklU=",
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "glob-parent": {
+            "version": "5.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/glob-parent/-/glob-parent-5.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fglob-parent%2F-%2Fglob-parent-5.0.0.tgz",
+            "integrity": "sha1-HcmfDzmwBtPpLCwoQGg4Lwwg6VQ=",
+            "dev": true,
+            "requires": {
+                "is-glob": "^4.0.1"
+            }
+        },
+        "globals": {
+            "version": "11.12.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/globals/-/globals-11.12.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fglobals%2F-%2Fglobals-11.12.0.tgz",
+            "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
+            "dev": true
+        },
+        "got": {
+            "version": "8.3.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/got/-/got-8.3.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fgot%2F-%2Fgot-8.3.2.tgz",
+            "integrity": "sha1-HSP2Q5Dpf3dsrFLluTbl9RTS6Tc=",
+            "requires": {
+                "@sindresorhus/is": "^0.7.0",
+                "cacheable-request": "^2.1.1",
+                "decompress-response": "^3.3.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "into-stream": "^3.1.0",
+                "is-retry-allowed": "^1.1.0",
+                "isurl": "^1.0.0-alpha5",
+                "lowercase-keys": "^1.0.0",
+                "mimic-response": "^1.0.0",
+                "p-cancelable": "^0.4.0",
+                "p-timeout": "^2.0.1",
+                "pify": "^3.0.0",
+                "safe-buffer": "^5.1.1",
+                "timed-out": "^4.0.1",
+                "url-parse-lax": "^3.0.0",
+                "url-to-options": "^1.0.1"
+            }
+        },
+        "graceful-fs": {
+            "version": "4.2.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/graceful-fs/-/graceful-fs-4.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fgraceful-fs%2F-%2Fgraceful-fs-4.2.2.tgz",
+            "integrity": "sha1-bwlSYF0BQMHP2xOO0AV3W5LWewI=",
+            "dev": true
+        },
+        "graceful-readlink": {
+            "version": "1.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/graceful-readlink/-/graceful-readlink-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fgraceful-readlink%2F-%2Fgraceful-readlink-1.0.1.tgz",
+            "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+            "dev": true
+        },
+        "greedy-interval-packer": {
+            "version": "1.2.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/greedy-interval-packer/-/greedy-interval-packer-1.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fgreedy-interval-packer%2F-%2Fgreedy-interval-packer-1.2.0.tgz",
+            "integrity": "sha1-1toR82Ybt5eBLaeKHqUQZ4oqhzk=",
+            "dev": true
+        },
+        "growl": {
+            "version": "1.10.5",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/growl/-/growl-1.10.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fgrowl%2F-%2Fgrowl-1.10.5.tgz",
+            "integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4=",
+            "dev": true
+        },
+        "handlebars": {
+            "version": "4.1.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/handlebars/-/handlebars-4.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhandlebars%2F-%2Fhandlebars-4.1.2.tgz",
+            "integrity": "sha1-trN8HO0DBrIh4JT8eso+wjsTG2c=",
+            "dev": true,
+            "requires": {
+                "neo-async": "^2.6.0",
+                "optimist": "^0.6.1",
+                "source-map": "^0.6.1",
+                "uglify-js": "^3.1.4"
+            }
+        },
+        "har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/har-schema/-/har-schema-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhar-schema%2F-%2Fhar-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+        },
+        "har-validator": {
+            "version": "5.1.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/har-validator/-/har-validator-5.1.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhar-validator%2F-%2Fhar-validator-5.1.3.tgz",
+            "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
+            "requires": {
+                "ajv": "^6.5.5",
+                "har-schema": "^2.0.0"
+            }
+        },
+        "has-flag": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/has-flag/-/has-flag-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhas-flag%2F-%2Fhas-flag-1.0.0.tgz",
+            "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+            "dev": true
+        },
+        "has-symbol-support-x": {
+            "version": "1.4.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhas-symbol-support-x%2F-%2Fhas-symbol-support-x-1.4.2.tgz",
+            "integrity": "sha1-FAn5i8ACR9pF2mfO4KNvKC/yZFU="
+        },
+        "has-to-string-tag-x": {
+            "version": "1.4.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhas-to-string-tag-x%2F-%2Fhas-to-string-tag-x-1.4.1.tgz",
+            "integrity": "sha1-oEWrOD17SyASoAFIqwql8pAETU0=",
+            "requires": {
+                "has-symbol-support-x": "^1.4.1"
+            }
+        },
+        "hasha": {
+            "version": "3.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/hasha/-/hasha-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhasha%2F-%2Fhasha-3.0.0.tgz",
+            "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
+            "dev": true,
+            "requires": {
+                "is-stream": "^1.0.1"
+            }
+        },
+        "he": {
+            "version": "1.1.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/he/-/he-1.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhe%2F-%2Fhe-1.1.1.tgz",
+            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+            "dev": true
+        },
+        "hosted-git-info": {
+            "version": "2.8.4",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/hosted-git-info/-/hosted-git-info-2.8.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhosted-git-info%2F-%2Fhosted-git-info-2.8.4.tgz",
+            "integrity": "sha1-RBGauvS8ZGkqFqzjRwD+2cA+JUY=",
+            "dev": true
+        },
+        "http-cache-semantics": {
+            "version": "3.8.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhttp-cache-semantics%2F-%2Fhttp-cache-semantics-3.8.1.tgz",
+            "integrity": "sha1-ObDhat2bYFvwqe89nar0hDtMrNI="
+        },
+        "http-signature": {
+            "version": "1.2.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/http-signature/-/http-signature-1.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhttp-signature%2F-%2Fhttp-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
+            }
+        },
+        "https-proxy-agent": {
+            "version": "2.2.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhttps-proxy-agent%2F-%2Fhttps-proxy-agent-2.2.2.tgz",
+            "integrity": "sha1-Jx6o6Q+DasnxGdrM05wZ/337B5M=",
+            "requires": {
+                "agent-base": "^4.3.0",
+                "debug": "^3.1.0"
+            }
+        },
+        "iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/iconv-lite/-/iconv-lite-0.4.24.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ficonv-lite%2F-%2Ficonv-lite-0.4.24.tgz",
+            "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+            "dev": true,
+            "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            }
+        },
+        "ignore": {
+            "version": "4.0.6",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/ignore/-/ignore-4.0.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fignore%2F-%2Fignore-4.0.6.tgz",
+            "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw=",
+            "dev": true
+        },
+        "import-fresh": {
+            "version": "3.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/import-fresh/-/import-fresh-3.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fimport-fresh%2F-%2Fimport-fresh-3.1.0.tgz",
+            "integrity": "sha1-bTP6Hc7235MPrgA0RvM0Fa+QURg=",
+            "dev": true,
+            "requires": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            }
+        },
+        "imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/imurmurhash/-/imurmurhash-0.1.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fimurmurhash%2F-%2Fimurmurhash-0.1.4.tgz",
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "dev": true
+        },
+        "indent-string": {
+            "version": "3.2.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/indent-string/-/indent-string-3.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Findent-string%2F-%2Findent-string-3.2.0.tgz",
+            "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/inflight/-/inflight-1.0.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Finflight%2F-%2Finflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/inherits/-/inherits-2.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Finherits%2F-%2Finherits-2.0.4.tgz",
+            "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
+        },
+        "inquirer": {
+            "version": "6.5.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/inquirer/-/inquirer-6.5.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Finquirer%2F-%2Finquirer-6.5.2.tgz",
+            "integrity": "sha1-rVCUI3XQNtMn/1KMCL1fqwiZKMo=",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "^3.2.0",
+                "chalk": "^2.4.2",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^3.0.3",
+                "figures": "^2.0.0",
+                "lodash": "^4.17.12",
+                "mute-stream": "0.0.7",
+                "run-async": "^2.2.0",
+                "rxjs": "^6.4.0",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^5.1.0",
+                "through": "^2.3.6"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/ansi-regex/-/ansi-regex-4.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-regex%2F-%2Fansi-regex-4.1.0.tgz",
+                    "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/strip-ansi/-/strip-ansi-5.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstrip-ansi%2F-%2Fstrip-ansi-5.2.0.tgz",
+                    "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
+            }
+        },
+        "intercept-stdout": {
+            "version": "0.1.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/intercept-stdout/-/intercept-stdout-0.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fintercept-stdout%2F-%2Fintercept-stdout-0.1.2.tgz",
+            "integrity": "sha1-Emq/H65sUJpCipjGGmMVWQQq6f0=",
+            "dev": true,
+            "requires": {
+                "lodash.toarray": "^3.0.0"
+            }
+        },
+        "interpret": {
+            "version": "1.2.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/interpret/-/interpret-1.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Finterpret%2F-%2Finterpret-1.2.0.tgz",
+            "integrity": "sha1-1QYaYiS+WOgIOYX1AU2EQ1lXYpY="
+        },
+        "into-stream": {
+            "version": "3.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/into-stream/-/into-stream-3.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Finto-stream%2F-%2Finto-stream-3.1.0.tgz",
+            "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+            "requires": {
+                "from2": "^2.1.1",
+                "p-is-promise": "^1.1.0"
+            }
+        },
+        "is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/is-arrayish/-/is-arrayish-0.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-arrayish%2F-%2Fis-arrayish-0.2.1.tgz",
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
+        },
+        "is-binary-path": {
+            "version": "2.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/is-binary-path/-/is-binary-path-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-binary-path%2F-%2Fis-binary-path-2.1.0.tgz",
+            "integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
+            "dev": true,
+            "requires": {
+                "binary-extensions": "^2.0.0"
+            }
+        },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/is-buffer/-/is-buffer-1.1.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-buffer%2F-%2Fis-buffer-1.1.6.tgz",
+            "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
+        },
+        "is-extendable": {
+            "version": "0.1.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/is-extendable/-/is-extendable-0.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-extendable%2F-%2Fis-extendable-0.1.1.tgz",
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+        },
+        "is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/is-extglob/-/is-extglob-2.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-extglob%2F-%2Fis-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "dev": true
+        },
+        "is-finite": {
+            "version": "1.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/is-finite/-/is-finite-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-finite%2F-%2Fis-finite-1.0.2.tgz",
+            "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+            "dev": true,
+            "requires": {
+                "number-is-nan": "^1.0.0"
+            }
+        },
+        "is-fullwidth-code-point": {
+            "version": "2.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-fullwidth-code-point%2F-%2Fis-fullwidth-code-point-2.0.0.tgz",
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+            "dev": true
+        },
+        "is-glob": {
+            "version": "4.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/is-glob/-/is-glob-4.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-glob%2F-%2Fis-glob-4.0.1.tgz",
+            "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
+            "dev": true,
+            "requires": {
+                "is-extglob": "^2.1.1"
+            }
+        },
+        "is-number": {
+            "version": "7.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/is-number/-/is-number-7.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-number%2F-%2Fis-number-7.0.0.tgz",
+            "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
+            "dev": true
+        },
+        "is-object": {
+            "version": "1.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/is-object/-/is-object-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-object%2F-%2Fis-object-1.0.1.tgz",
+            "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+        },
+        "is-plain-obj": {
+            "version": "1.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/is-plain-obj/-/is-plain-obj-1.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-plain-obj%2F-%2Fis-plain-obj-1.1.0.tgz",
+            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+        },
+        "is-plain-object": {
+            "version": "2.0.4",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/is-plain-object/-/is-plain-object-2.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-plain-object%2F-%2Fis-plain-object-2.0.4.tgz",
+            "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+            "requires": {
+                "isobject": "^3.0.1"
+            }
+        },
+        "is-promise": {
+            "version": "2.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/is-promise/-/is-promise-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-promise%2F-%2Fis-promise-2.1.0.tgz",
+            "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+            "dev": true
+        },
+        "is-retry-allowed": {
+            "version": "1.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-retry-allowed%2F-%2Fis-retry-allowed-1.1.0.tgz",
+            "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+        },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/is-stream/-/is-stream-1.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-stream%2F-%2Fis-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "dev": true
+        },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/is-typedarray/-/is-typedarray-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-typedarray%2F-%2Fis-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/isarray/-/isarray-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fisarray%2F-%2Fisarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/isexe/-/isexe-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fisexe%2F-%2Fisexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
+        },
+        "isobject": {
+            "version": "3.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/isobject/-/isobject-3.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fisobject%2F-%2Fisobject-3.0.1.tgz",
+            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        },
+        "isomorphic-ws": {
+            "version": "4.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fisomorphic-ws%2F-%2Fisomorphic-ws-4.0.1.tgz",
+            "integrity": "sha1-Vf1M1sXmSR523BJZON2GP1zU8tw="
+        },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/isstream/-/isstream-0.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fisstream%2F-%2Fisstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+        },
+        "istanbul-lib-coverage": {
+            "version": "2.0.5",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fistanbul-lib-coverage%2F-%2Fistanbul-lib-coverage-2.0.5.tgz",
+            "integrity": "sha1-Z18KtpUD+tSx2En3NrqsqAM0T0k=",
+            "dev": true
+        },
+        "istanbul-lib-hook": {
+            "version": "2.0.7",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fistanbul-lib-hook%2F-%2Fistanbul-lib-hook-2.0.7.tgz",
+            "integrity": "sha1-yVaV84PU+PYN8fBCUqlVDhW1sTM=",
+            "dev": true,
+            "requires": {
+                "append-transform": "^1.0.0"
+            }
+        },
+        "istanbul-lib-instrument": {
+            "version": "3.3.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fistanbul-lib-instrument%2F-%2Fistanbul-lib-instrument-3.3.0.tgz",
+            "integrity": "sha1-pfY9kfC7wMPkee9MXeAnM17G1jA=",
+            "dev": true,
+            "requires": {
+                "@babel/generator": "^7.4.0",
+                "@babel/parser": "^7.4.3",
+                "@babel/template": "^7.4.0",
+                "@babel/traverse": "^7.4.3",
+                "@babel/types": "^7.4.0",
+                "istanbul-lib-coverage": "^2.0.5",
+                "semver": "^6.0.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/semver/-/semver-6.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsemver%2F-%2Fsemver-6.3.0.tgz",
+                    "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+                    "dev": true
+                }
+            }
+        },
+        "istanbul-lib-processinfo": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/istanbul-lib-processinfo/-/istanbul-lib-processinfo-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fistanbul-lib-processinfo%2F-%2Fistanbul-lib-processinfo-1.0.0.tgz",
+            "integrity": "sha1-bAtZQR0olzE+oJFl/ZVGSjK+VhA=",
+            "dev": true,
+            "requires": {
+                "archy": "^1.0.0",
+                "cross-spawn": "^6.0.5",
+                "istanbul-lib-coverage": "^2.0.3",
+                "rimraf": "^2.6.3",
+                "uuid": "^3.3.2"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/cross-spawn/-/cross-spawn-6.0.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcross-spawn%2F-%2Fcross-spawn-6.0.5.tgz",
+                    "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/semver/-/semver-5.7.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsemver%2F-%2Fsemver-5.7.1.tgz",
+                    "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+                    "dev": true
+                },
+                "uuid": {
+                    "version": "3.3.3",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/uuid/-/uuid-3.3.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fuuid%2F-%2Fuuid-3.3.3.tgz",
+                    "integrity": "sha1-RWjwIW54dg7h2/Ok0s9T4iQRKGY=",
+                    "dev": true
+                }
+            }
+        },
+        "istanbul-lib-report": {
+            "version": "2.0.8",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fistanbul-lib-report%2F-%2Fistanbul-lib-report-2.0.8.tgz",
+            "integrity": "sha1-WoETzXRtQ8SInro2qxDn1QybTzM=",
+            "dev": true,
+            "requires": {
+                "istanbul-lib-coverage": "^2.0.5",
+                "make-dir": "^2.1.0",
+                "supports-color": "^6.1.0"
+            },
+            "dependencies": {
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/has-flag/-/has-flag-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhas-flag%2F-%2Fhas-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/supports-color/-/supports-color-6.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsupports-color%2F-%2Fsupports-color-6.1.0.tgz",
+                    "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "istanbul-lib-source-maps": {
+            "version": "3.0.6",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fistanbul-lib-source-maps%2F-%2Fistanbul-lib-source-maps-3.0.6.tgz",
+            "integrity": "sha1-KEmXxIIRdS7EhiU9qX44ed77qMg=",
+            "dev": true,
+            "requires": {
+                "debug": "^4.1.1",
+                "istanbul-lib-coverage": "^2.0.5",
+                "make-dir": "^2.1.0",
+                "rimraf": "^2.6.3",
+                "source-map": "^0.6.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/debug/-/debug-4.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdebug%2F-%2Fdebug-4.1.1.tgz",
+                    "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                }
+            }
+        },
+        "istanbul-reports": {
+            "version": "2.2.6",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/istanbul-reports/-/istanbul-reports-2.2.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fistanbul-reports%2F-%2Fistanbul-reports-2.2.6.tgz",
+            "integrity": "sha1-e08mYNgrKTA6j+YJH4ykvwWNoa8=",
+            "dev": true,
+            "requires": {
+                "handlebars": "^4.1.2"
+            }
+        },
+        "isurl": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/isurl/-/isurl-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fisurl%2F-%2Fisurl-1.0.0.tgz",
+            "integrity": "sha1-sn9PSfPNqj6kSgpbfzRi5u3DnWc=",
+            "requires": {
+                "has-to-string-tag-x": "^1.2.0",
+                "is-object": "^1.0.1"
+            }
+        },
+        "jackspeak": {
+            "version": "1.4.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/jackspeak/-/jackspeak-1.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjackspeak%2F-%2Fjackspeak-1.4.0.tgz",
+            "integrity": "sha1-TrLHk1xebSgXm1CClxHRNyocmio=",
+            "dev": true,
+            "requires": {
+                "cliui": "^4.1.0"
+            }
+        },
+        "js-yaml": {
+            "version": "3.13.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/js-yaml/-/js-yaml-3.13.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjs-yaml%2F-%2Fjs-yaml-3.13.1.tgz",
+            "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            }
+        },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/jsbn/-/jsbn-0.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjsbn%2F-%2Fjsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+        },
+        "jsesc": {
+            "version": "2.5.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/jsesc/-/jsesc-2.5.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjsesc%2F-%2Fjsesc-2.5.2.tgz",
+            "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
+            "dev": true
+        },
+        "json-buffer": {
+            "version": "3.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/json-buffer/-/json-buffer-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjson-buffer%2F-%2Fjson-buffer-3.0.0.tgz",
+            "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
+        },
+        "json-parse-better-errors": {
+            "version": "1.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjson-parse-better-errors%2F-%2Fjson-parse-better-errors-1.0.2.tgz",
+            "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
+            "dev": true
+        },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/json-schema/-/json-schema-0.2.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjson-schema%2F-%2Fjson-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+        },
+        "json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjson-schema-traverse%2F-%2Fjson-schema-traverse-0.4.1.tgz",
+            "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA="
+        },
+        "json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjson-stable-stringify-without-jsonify%2F-%2Fjson-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
+        },
+        "json-stream": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/json-stream/-/json-stream-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjson-stream%2F-%2Fjson-stream-1.0.0.tgz",
+            "integrity": "sha1-GjhU4o0rvuqzHMfd9oPS3cVlJwg="
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjson-stringify-safe%2F-%2Fjson-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+        },
+        "json3": {
+            "version": "3.3.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/json3/-/json3-3.3.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjson3%2F-%2Fjson3-3.3.2.tgz",
+            "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+            "dev": true
+        },
+        "jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/jsonfile/-/jsonfile-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjsonfile%2F-%2Fjsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "jsonpath-plus": {
+            "version": "0.19.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/jsonpath-plus/-/jsonpath-plus-0.19.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjsonpath-plus%2F-%2Fjsonpath-plus-0.19.0.tgz",
+            "integrity": "sha1-uQHldgcFWTPcmovvDMJRYO6d1kw="
+        },
+        "jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/jsprim/-/jsprim-1.4.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fjsprim%2F-%2Fjsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            }
+        },
+        "keyv": {
+            "version": "3.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/keyv/-/keyv-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fkeyv%2F-%2Fkeyv-3.0.0.tgz",
+            "integrity": "sha1-RJI7o55osSp87H32wyaMAx8u83M=",
+            "requires": {
+                "json-buffer": "3.0.0"
+            }
+        },
+        "kind-of": {
+            "version": "3.2.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/kind-of/-/kind-of-3.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fkind-of%2F-%2Fkind-of-3.2.2.tgz",
+            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+            "requires": {
+                "is-buffer": "^1.1.5"
+            }
+        },
+        "kubernetes-client": {
+            "version": "8.3.4",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/kubernetes-client/-/kubernetes-client-8.3.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fkubernetes-client%2F-%2Fkubernetes-client-8.3.4.tgz",
+            "integrity": "sha1-Fjn7ctK7OnjMXgLogn+aqyBJYMg=",
+            "requires": {
+                "@kubernetes/client-node": "0.10.2",
+                "camelcase": "^5.3.1",
+                "deepmerge": "^4.0.0",
+                "depd": "^2.0.0",
+                "js-yaml": "^3.13.1",
+                "json-stream": "^1.0.0",
+                "openid-client": "2.5.0",
+                "pump": "^3.0.0",
+                "qs": "^6.7.0",
+                "request": "^2.88.0",
+                "swagger-fluent": "^3.2.1",
+                "url-join": "^4.0.0",
+                "ws": "^7.0.0"
+            }
+        },
+        "lazy-cache": {
+            "version": "1.0.4",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/lazy-cache/-/lazy-cache-1.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flazy-cache%2F-%2Flazy-cache-1.0.4.tgz",
+            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+        },
+        "lcov-parse": {
+            "version": "0.0.10",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/lcov-parse/-/lcov-parse-0.0.10.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flcov-parse%2F-%2Flcov-parse-0.0.10.tgz",
+            "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+            "dev": true
+        },
+        "leven": {
+            "version": "2.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/leven/-/leven-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fleven%2F-%2Fleven-2.1.0.tgz",
+            "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+            "dev": true
+        },
+        "levn": {
+            "version": "0.3.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/levn/-/levn-0.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flevn%2F-%2Flevn-0.3.0.tgz",
+            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
+            }
+        },
+        "load-json-file": {
+            "version": "4.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/load-json-file/-/load-json-file-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fload-json-file%2F-%2Fload-json-file-4.0.0.tgz",
+            "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
+            }
+        },
+        "locate-path": {
+            "version": "3.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/locate-path/-/locate-path-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flocate-path%2F-%2Flocate-path-3.0.0.tgz",
+            "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+            "dev": true,
+            "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+            }
+        },
+        "lodash": {
+            "version": "4.17.15",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/lodash/-/lodash-4.17.15.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash%2F-%2Flodash-4.17.15.tgz",
+            "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg="
+        },
+        "lodash._arraycopy": {
+            "version": "3.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash._arraycopy%2F-%2Flodash._arraycopy-3.0.0.tgz",
+            "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
+            "dev": true
+        },
+        "lodash._baseassign": {
+            "version": "3.2.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash._baseassign%2F-%2Flodash._baseassign-3.2.0.tgz",
+            "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+            "dev": true,
+            "requires": {
+                "lodash._basecopy": "^3.0.0",
+                "lodash.keys": "^3.0.0"
+            }
+        },
+        "lodash._basecopy": {
+            "version": "3.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash._basecopy%2F-%2Flodash._basecopy-3.0.1.tgz",
+            "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+            "dev": true
+        },
+        "lodash._basecreate": {
+            "version": "3.0.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash._basecreate%2F-%2Flodash._basecreate-3.0.3.tgz",
+            "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+            "dev": true
+        },
+        "lodash._basevalues": {
+            "version": "3.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash._basevalues%2F-%2Flodash._basevalues-3.0.0.tgz",
+            "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+            "dev": true
+        },
+        "lodash._getnative": {
+            "version": "3.9.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/lodash._getnative/-/lodash._getnative-3.9.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash._getnative%2F-%2Flodash._getnative-3.9.1.tgz",
+            "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+            "dev": true
+        },
+        "lodash._isiterateecall": {
+            "version": "3.0.9",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash._isiterateecall%2F-%2Flodash._isiterateecall-3.0.9.tgz",
+            "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+            "dev": true
+        },
+        "lodash.create": {
+            "version": "3.1.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/lodash.create/-/lodash.create-3.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash.create%2F-%2Flodash.create-3.1.1.tgz",
+            "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+            "dev": true,
+            "requires": {
+                "lodash._baseassign": "^3.0.0",
+                "lodash._basecreate": "^3.0.0",
+                "lodash._isiterateecall": "^3.0.0"
+            }
+        },
+        "lodash.flattendeep": {
+            "version": "4.4.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash.flattendeep%2F-%2Flodash.flattendeep-4.4.0.tgz",
+            "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+            "dev": true
+        },
+        "lodash.isarguments": {
+            "version": "3.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash.isarguments%2F-%2Flodash.isarguments-3.1.0.tgz",
+            "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+            "dev": true
+        },
+        "lodash.isarray": {
+            "version": "3.0.4",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/lodash.isarray/-/lodash.isarray-3.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash.isarray%2F-%2Flodash.isarray-3.0.4.tgz",
+            "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+            "dev": true
+        },
+        "lodash.keys": {
+            "version": "3.1.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/lodash.keys/-/lodash.keys-3.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash.keys%2F-%2Flodash.keys-3.1.2.tgz",
+            "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+            "dev": true,
+            "requires": {
+                "lodash._getnative": "^3.0.0",
+                "lodash.isarguments": "^3.0.0",
+                "lodash.isarray": "^3.0.0"
+            }
+        },
+        "lodash.toarray": {
+            "version": "3.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/lodash.toarray/-/lodash.toarray-3.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flodash.toarray%2F-%2Flodash.toarray-3.0.2.tgz",
+            "integrity": "sha1-KyBPD6T1HChcbwDIHRzqWiMEEXk=",
+            "dev": true,
+            "requires": {
+                "lodash._arraycopy": "^3.0.0",
+                "lodash._basevalues": "^3.0.0",
+                "lodash.keys": "^3.0.0"
+            }
+        },
+        "log-driver": {
+            "version": "1.2.7",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/log-driver/-/log-driver-1.2.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flog-driver%2F-%2Flog-driver-1.2.7.tgz",
+            "integrity": "sha1-Y7lQIfBwL+36LJuwok53l9cYcdg=",
+            "dev": true
+        },
+        "log4js": {
+            "version": "0.6.38",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/log4js/-/log4js-0.6.38.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flog4js%2F-%2Flog4js-0.6.38.tgz",
+            "integrity": "sha1-LElBFmldb7JUgJQ9P8hy5mKlIv0=",
+            "requires": {
+                "readable-stream": "~1.0.2",
+                "semver": "~4.3.3"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/isarray/-/isarray-0.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fisarray%2F-%2Fisarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+                },
+                "readable-stream": {
+                    "version": "1.0.34",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/readable-stream/-/readable-stream-1.0.34.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Freadable-stream%2F-%2Freadable-stream-1.0.34.tgz",
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "0.0.1",
+                        "string_decoder": "~0.10.x"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/string_decoder/-/string_decoder-0.10.31.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstring_decoder%2F-%2Fstring_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                }
+            }
+        },
+        "long": {
+            "version": "4.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/long/-/long-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flong%2F-%2Flong-4.0.0.tgz",
+            "integrity": "sha1-mntxz7fTYaGU6lVSQckvdGjVvyg="
+        },
+        "lowercase-keys": {
+            "version": "1.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/lowercase-keys/-/lowercase-keys-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flowercase-keys%2F-%2Flowercase-keys-1.0.1.tgz",
+            "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8="
+        },
+        "lru-cache": {
+            "version": "5.1.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/lru-cache/-/lru-cache-5.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flru-cache%2F-%2Flru-cache-5.1.1.tgz",
+            "integrity": "sha1-HaJ+ZxAnGUdpXa9oSOhH8B2EuSA=",
+            "requires": {
+                "yallist": "^3.0.2"
+            }
+        },
+        "magicpen": {
+            "version": "5.12.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/magicpen/-/magicpen-5.12.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmagicpen%2F-%2Fmagicpen-5.12.0.tgz",
+            "integrity": "sha1-u+nunUI2R2rs+EE27KGDPrRwqWs=",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "2.0.0",
+                "color-diff": "0.1.7",
+                "supports-color": "1.2.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.0.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/ansi-styles/-/ansi-styles-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-styles%2F-%2Fansi-styles-2.0.0.tgz",
+                    "integrity": "sha1-QysmFi/qG2PIeIlqvIzFVI8lBj4=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "1.2.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/supports-color/-/supports-color-1.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsupports-color%2F-%2Fsupports-color-1.2.0.tgz",
+                    "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+                    "dev": true
+                }
+            }
+        },
+        "make-dir": {
+            "version": "2.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/make-dir/-/make-dir-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmake-dir%2F-%2Fmake-dir-2.1.0.tgz",
+            "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+            "dev": true,
+            "requires": {
+                "pify": "^4.0.1",
+                "semver": "^5.6.0"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/pify/-/pify-4.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpify%2F-%2Fpify-4.0.1.tgz",
+                    "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/semver/-/semver-5.7.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsemver%2F-%2Fsemver-5.7.1.tgz",
+                    "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+                    "dev": true
+                }
+            }
+        },
+        "make-error": {
+            "version": "1.3.5",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/make-error/-/make-error-1.3.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmake-error%2F-%2Fmake-error-1.3.5.tgz",
+            "integrity": "sha1-7+ToH22yjK3WBccPKcgxtY73dsg=",
+            "dev": true
+        },
+        "md5": {
+            "version": "2.2.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/md5/-/md5-2.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmd5%2F-%2Fmd5-2.2.1.tgz",
+            "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+            "dev": true,
+            "requires": {
+                "charenc": "~0.0.1",
+                "crypt": "~0.0.1",
+                "is-buffer": "~1.1.1"
+            }
+        },
+        "merge-deep": {
+            "version": "3.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/merge-deep/-/merge-deep-3.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmerge-deep%2F-%2Fmerge-deep-3.0.2.tgz",
+            "integrity": "sha1-85+hAKTxvTT/KffSv0UI+7jYOtI=",
+            "requires": {
+                "arr-union": "^3.1.0",
+                "clone-deep": "^0.2.4",
+                "kind-of": "^3.0.2"
+            }
+        },
+        "merge-source-map": {
+            "version": "1.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/merge-source-map/-/merge-source-map-1.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmerge-source-map%2F-%2Fmerge-source-map-1.1.0.tgz",
+            "integrity": "sha1-L93n5gIJOfcJBqaPLXrmheTIxkY=",
+            "dev": true,
+            "requires": {
+                "source-map": "^0.6.1"
+            }
+        },
+        "mime-db": {
+            "version": "1.40.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/mime-db/-/mime-db-1.40.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmime-db%2F-%2Fmime-db-1.40.0.tgz",
+            "integrity": "sha1-plBX6ZjbCQ9zKmj2wnbTh9QSbDI="
+        },
+        "mime-types": {
+            "version": "2.1.24",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/mime-types/-/mime-types-2.1.24.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmime-types%2F-%2Fmime-types-2.1.24.tgz",
+            "integrity": "sha1-tvjQs+lR77d97eyhlM/20W9nb4E=",
+            "requires": {
+                "mime-db": "1.40.0"
+            }
+        },
+        "mimic-fn": {
+            "version": "1.2.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/mimic-fn/-/mimic-fn-1.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmimic-fn%2F-%2Fmimic-fn-1.2.0.tgz",
+            "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
+            "dev": true
+        },
+        "mimic-response": {
+            "version": "1.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/mimic-response/-/mimic-response-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmimic-response%2F-%2Fmimic-response-1.0.1.tgz",
+            "integrity": "sha1-SSNTiHju9CBjy4o+OweYeBSHqxs="
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/minimatch/-/minimatch-3.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fminimatch%2F-%2Fminimatch-3.0.4.tgz",
+            "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "1.2.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/minimist/-/minimist-1.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fminimist%2F-%2Fminimist-1.2.0.tgz",
+            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+            "dev": true
+        },
+        "minipass": {
+            "version": "2.5.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/minipass/-/minipass-2.5.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fminipass%2F-%2Fminipass-2.5.0.tgz",
+            "integrity": "sha1-3dsdABl2l4FYoFut/L70p3FhKFc=",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+            }
+        },
+        "mixin-object": {
+            "version": "2.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/mixin-object/-/mixin-object-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmixin-object%2F-%2Fmixin-object-2.0.1.tgz",
+            "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
+            "requires": {
+                "for-in": "^0.1.3",
+                "is-extendable": "^0.1.1"
+            },
+            "dependencies": {
+                "for-in": {
+                    "version": "0.1.8",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/for-in/-/for-in-0.1.8.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ffor-in%2F-%2Ffor-in-0.1.8.tgz",
+                    "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE="
+                }
+            }
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/mkdirp/-/mkdirp-0.5.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmkdirp%2F-%2Fmkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true,
+            "requires": {
+                "minimist": "0.0.8"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.8",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/minimist/-/minimist-0.0.8.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fminimist%2F-%2Fminimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "dev": true
+                }
+            }
+        },
+        "mocha": {
+            "version": "3.5.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/mocha/-/mocha-3.5.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmocha%2F-%2Fmocha-3.5.3.tgz",
+            "integrity": "sha1-HgSA/jbS2lhY0etqzDhBiybqog0=",
+            "dev": true,
+            "requires": {
+                "browser-stdout": "1.3.0",
+                "commander": "2.9.0",
+                "debug": "2.6.8",
+                "diff": "3.2.0",
+                "escape-string-regexp": "1.0.5",
+                "glob": "7.1.1",
+                "growl": "1.9.2",
+                "he": "1.1.1",
+                "json3": "3.3.2",
+                "lodash.create": "3.1.1",
+                "mkdirp": "0.5.1",
+                "supports-color": "3.1.2"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.8",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/debug/-/debug-2.6.8.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdebug%2F-%2Fdebug-2.6.8.tgz",
+                    "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.1",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/glob/-/glob-7.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fglob%2F-%2Fglob-7.1.1.tgz",
+                    "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "growl": {
+                    "version": "1.9.2",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/growl/-/growl-1.9.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fgrowl%2F-%2Fgrowl-1.9.2.tgz",
+                    "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/ms/-/ms-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fms%2F-%2Fms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "3.1.2",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/supports-color/-/supports-color-3.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsupports-color%2F-%2Fsupports-color-3.1.2.tgz",
+                    "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "mocha-junit-reporter": {
+            "version": "1.23.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/mocha-junit-reporter/-/mocha-junit-reporter-1.23.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmocha-junit-reporter%2F-%2Fmocha-junit-reporter-1.23.1.tgz",
+            "integrity": "sha1-uhFRnAuWf0BOQSPdabxLoCKrDxI=",
+            "dev": true,
+            "requires": {
+                "debug": "^2.2.0",
+                "md5": "^2.1.0",
+                "mkdirp": "~0.5.1",
+                "strip-ansi": "^4.0.0",
+                "xml": "^1.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/ansi-regex/-/ansi-regex-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-regex%2F-%2Fansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/debug/-/debug-2.6.9.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdebug%2F-%2Fdebug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/ms/-/ms-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fms%2F-%2Fms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/strip-ansi/-/strip-ansi-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstrip-ansi%2F-%2Fstrip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "ms": {
+            "version": "2.1.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/ms/-/ms-2.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fms%2F-%2Fms-2.1.2.tgz",
+            "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk="
+        },
+        "mute-stream": {
+            "version": "0.0.7",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/mute-stream/-/mute-stream-0.0.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fmute-stream%2F-%2Fmute-stream-0.0.7.tgz",
+            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+            "dev": true
+        },
+        "natural-compare": {
+            "version": "1.4.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/natural-compare/-/natural-compare-1.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnatural-compare%2F-%2Fnatural-compare-1.4.0.tgz",
+            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
+        "neo-async": {
+            "version": "2.6.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/neo-async/-/neo-async-2.6.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fneo-async%2F-%2Fneo-async-2.6.1.tgz",
+            "integrity": "sha1-rCetpmFn+ohJpq3dg39rGJrSCBw=",
+            "dev": true
+        },
+        "nested-error-stacks": {
+            "version": "2.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnested-error-stacks%2F-%2Fnested-error-stacks-2.1.0.tgz",
+            "integrity": "sha1-D73PPhP+SZR4EoBST4uWsM3/nGE=",
+            "dev": true
+        },
+        "nice-try": {
+            "version": "1.0.5",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/nice-try/-/nice-try-1.0.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnice-try%2F-%2Fnice-try-1.0.5.tgz",
+            "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
+            "dev": true
+        },
+        "node-forge": {
+            "version": "0.8.5",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/node-forge/-/node-forge-0.8.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnode-forge%2F-%2Fnode-forge-0.8.5.tgz",
+            "integrity": "sha1-V5BvB2FNxydiyEzvRC9CfA4bhu4="
+        },
+        "node-jose": {
+            "version": "1.1.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/node-jose/-/node-jose-1.1.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnode-jose%2F-%2Fnode-jose-1.1.3.tgz",
+            "integrity": "sha1-Jua8VjEBo1bAb7JUx+8AeOi0lnA=",
+            "requires": {
+                "base64url": "^3.0.1",
+                "es6-promise": "^4.2.6",
+                "lodash": "^4.17.11",
+                "long": "^4.0.0",
+                "node-forge": "^0.8.1",
+                "uuid": "^3.3.2"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "3.3.3",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/uuid/-/uuid-3.3.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fuuid%2F-%2Fuuid-3.3.3.tgz",
+                    "integrity": "sha1-RWjwIW54dg7h2/Ok0s9T4iQRKGY="
+                }
+            }
+        },
+        "node-modules-regexp": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnode-modules-regexp%2F-%2Fnode-modules-regexp-1.0.0.tgz",
+            "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+            "dev": true
+        },
+        "normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/normalize-package-data/-/normalize-package-data-2.5.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnormalize-package-data%2F-%2Fnormalize-package-data-2.5.0.tgz",
+            "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
+            "dev": true,
+            "requires": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            }
+        },
+        "normalize-path": {
+            "version": "3.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/normalize-path/-/normalize-path-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnormalize-path%2F-%2Fnormalize-path-3.0.0.tgz",
+            "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
+            "dev": true
+        },
+        "normalize-url": {
+            "version": "2.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/normalize-url/-/normalize-url-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnormalize-url%2F-%2Fnormalize-url-2.0.1.tgz",
+            "integrity": "sha1-g1qdoVUfom9w6SMpBpojqmV01+Y=",
+            "requires": {
+                "prepend-http": "^2.0.0",
+                "query-string": "^5.0.1",
+                "sort-keys": "^2.0.0"
+            }
+        },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/number-is-nan/-/number-is-nan-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnumber-is-nan%2F-%2Fnumber-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true
+        },
+        "nyc": {
+            "version": "11.9.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/nyc/-/nyc-11.9.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnyc%2F-%2Fnyc-11.9.0.tgz",
+            "integrity": "sha1-QQbono++c2I6H8i27Lerqica4eQ=",
+            "dev": true,
+            "requires": {
+                "archy": "^1.0.0",
+                "arrify": "^1.0.1",
+                "caching-transform": "^1.0.0",
+                "convert-source-map": "^1.5.1",
+                "debug-log": "^1.0.1",
+                "default-require-extensions": "^1.0.0",
+                "find-cache-dir": "^0.1.1",
+                "find-up": "^2.1.0",
+                "foreground-child": "^1.5.3",
+                "glob": "^7.0.6",
+                "istanbul-lib-coverage": "^1.1.2",
+                "istanbul-lib-hook": "^1.1.0",
+                "istanbul-lib-instrument": "^1.10.0",
+                "istanbul-lib-report": "^1.1.3",
+                "istanbul-lib-source-maps": "^1.2.3",
+                "istanbul-reports": "^1.4.0",
+                "md5-hex": "^1.2.0",
+                "merge-source-map": "^1.1.0",
+                "micromatch": "^3.1.10",
+                "mkdirp": "^0.5.0",
+                "resolve-from": "^2.0.0",
+                "rimraf": "^2.6.2",
+                "signal-exit": "^3.0.1",
+                "spawn-wrap": "^1.4.2",
+                "test-exclude": "^4.2.0",
+                "yargs": "11.1.0",
+                "yargs-parser": "^8.0.0"
+            },
+            "dependencies": {
+                "align-text": {
+                    "version": "0.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.0.2",
+                        "longest": "^1.0.1",
+                        "repeat-string": "^1.5.2"
+                    }
+                },
+                "amdefine": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "append-transform": {
+                    "version": "0.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "default-require-extensions": "^1.0.0"
+                    }
+                },
+                "archy": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "arr-diff": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "arr-flatten": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "arr-union": {
+                    "version": "3.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "array-unique": {
+                    "version": "0.3.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "arrify": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "assign-symbols": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "async": {
+                    "version": "1.5.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "atob": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "babel-code-frame": {
+                    "version": "6.26.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^1.1.3",
+                        "esutils": "^2.0.2",
+                        "js-tokens": "^3.0.2"
+                    }
+                },
+                "babel-generator": {
+                    "version": "6.26.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "babel-messages": "^6.23.0",
+                        "babel-runtime": "^6.26.0",
+                        "babel-types": "^6.26.0",
+                        "detect-indent": "^4.0.0",
+                        "jsesc": "^1.3.0",
+                        "lodash": "^4.17.4",
+                        "source-map": "^0.5.7",
+                        "trim-right": "^1.0.1"
+                    }
+                },
+                "babel-messages": {
+                    "version": "6.23.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "^6.22.0"
+                    }
+                },
+                "babel-runtime": {
+                    "version": "6.26.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "core-js": "^2.4.0",
+                        "regenerator-runtime": "^0.11.0"
+                    }
+                },
+                "babel-template": {
+                    "version": "6.26.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "^6.26.0",
+                        "babel-traverse": "^6.26.0",
+                        "babel-types": "^6.26.0",
+                        "babylon": "^6.18.0",
+                        "lodash": "^4.17.4"
+                    }
+                },
+                "babel-traverse": {
+                    "version": "6.26.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "babel-code-frame": "^6.26.0",
+                        "babel-messages": "^6.23.0",
+                        "babel-runtime": "^6.26.0",
+                        "babel-types": "^6.26.0",
+                        "babylon": "^6.18.0",
+                        "debug": "^2.6.8",
+                        "globals": "^9.18.0",
+                        "invariant": "^2.2.2",
+                        "lodash": "^4.17.4"
+                    }
+                },
+                "babel-types": {
+                    "version": "6.26.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "^6.26.0",
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.4",
+                        "to-fast-properties": "^1.0.3"
+                    }
+                },
+                "babylon": {
+                    "version": "6.18.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "base": {
+                    "version": "0.11.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cache-base": "^1.0.1",
+                        "class-utils": "^0.3.5",
+                        "component-emitter": "^1.2.1",
+                        "define-property": "^1.0.0",
+                        "isobject": "^3.0.1",
+                        "mixin-deep": "^1.2.0",
+                        "pascalcase": "^0.1.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "^1.0.0"
+                            }
+                        },
+                        "is-accessor-descriptor": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^6.0.0"
+                            }
+                        },
+                        "is-data-descriptor": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^6.0.0"
+                            }
+                        },
+                        "is-descriptor": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-accessor-descriptor": "^1.0.0",
+                                "is-data-descriptor": "^1.0.0",
+                                "kind-of": "^6.0.2"
+                            }
+                        },
+                        "isobject": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "kind-of": {
+                            "version": "6.0.2",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "braces": {
+                    "version": "2.3.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "builtin-modules": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "cache-base": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "collection-visit": "^1.0.0",
+                        "component-emitter": "^1.2.1",
+                        "get-value": "^2.0.6",
+                        "has-value": "^1.0.0",
+                        "isobject": "^3.0.1",
+                        "set-value": "^2.0.0",
+                        "to-object-path": "^0.3.0",
+                        "union-value": "^1.0.0",
+                        "unset-value": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "isobject": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "caching-transform": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "md5-hex": "^1.2.0",
+                        "mkdirp": "^0.5.1",
+                        "write-file-atomic": "^1.1.4"
+                    }
+                },
+                "camelcase": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "center-align": {
+                    "version": "0.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "align-text": "^0.1.3",
+                        "lazy-cache": "^1.0.3"
+                    }
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "class-utils": {
+                    "version": "0.3.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "arr-union": "^3.1.0",
+                        "define-property": "^0.2.5",
+                        "isobject": "^3.0.0",
+                        "static-extend": "^0.1.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "0.2.5",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "^0.1.0"
+                            }
+                        },
+                        "isobject": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "cliui": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "center-align": "^0.1.1",
+                        "right-align": "^0.1.1",
+                        "wordwrap": "0.0.2"
+                    },
+                    "dependencies": {
+                        "wordwrap": {
+                            "version": "0.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "collection-visit": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "map-visit": "^1.0.0",
+                        "object-visit": "^1.0.0"
+                    }
+                },
+                "commondir": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "component-emitter": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "convert-source-map": {
+                    "version": "1.5.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "copy-descriptor": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "core-js": {
+                    "version": "2.5.6",
+                    "bundled": true,
+                    "dev": true
+                },
+                "cross-spawn": {
+                    "version": "4.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^4.0.1",
+                        "which": "^1.2.9"
+                    }
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "debug-log": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "decamelize": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "decode-uri-component": {
+                    "version": "0.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "default-require-extensions": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "strip-bom": "^2.0.0"
+                    }
+                },
+                "define-property": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.2",
+                        "isobject": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "is-accessor-descriptor": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^6.0.0"
+                            }
+                        },
+                        "is-data-descriptor": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^6.0.0"
+                            }
+                        },
+                        "is-descriptor": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-accessor-descriptor": "^1.0.0",
+                                "is-data-descriptor": "^1.0.0",
+                                "kind-of": "^6.0.2"
+                            }
+                        },
+                        "isobject": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "kind-of": {
+                            "version": "6.0.2",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "detect-indent": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "repeating": "^2.0.0"
+                    }
+                },
+                "error-ex": {
+                    "version": "1.3.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-arrayish": "^0.2.1"
+                    }
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true
+                },
+                "esutils": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "execa": {
+                    "version": "0.7.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "cross-spawn": {
+                            "version": "5.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "lru-cache": "^4.0.1",
+                                "shebang-command": "^1.2.0",
+                                "which": "^1.2.9"
+                            }
+                        }
+                    }
+                },
+                "expand-brackets": {
+                    "version": "2.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "0.2.5",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "^0.1.0"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "extend-shallow": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "assign-symbols": "^1.0.0",
+                        "is-extendable": "^1.0.1"
+                    },
+                    "dependencies": {
+                        "is-extendable": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-plain-object": "^2.0.4"
+                            }
+                        }
+                    }
+                },
+                "extglob": {
+                    "version": "2.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "^1.0.0"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        },
+                        "is-accessor-descriptor": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^6.0.0"
+                            }
+                        },
+                        "is-data-descriptor": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^6.0.0"
+                            }
+                        },
+                        "is-descriptor": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-accessor-descriptor": "^1.0.0",
+                                "is-data-descriptor": "^1.0.0",
+                                "kind-of": "^6.0.2"
+                            }
+                        },
+                        "kind-of": {
+                            "version": "6.0.2",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "find-cache-dir": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "commondir": "^1.0.1",
+                        "mkdirp": "^0.5.1",
+                        "pkg-dir": "^1.0.0"
+                    }
+                },
+                "find-up": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^2.0.0"
+                    }
+                },
+                "for-in": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "foreground-child": {
+                    "version": "1.5.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^4",
+                        "signal-exit": "^3.0.0"
+                    }
+                },
+                "fragment-cache": {
+                    "version": "0.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "map-cache": "^0.2.2"
+                    }
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "get-caller-file": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "get-stream": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "get-value": {
+                    "version": "2.0.6",
+                    "bundled": true,
+                    "dev": true
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "globals": {
+                    "version": "9.18.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "bundled": true,
+                    "dev": true
+                },
+                "handlebars": {
+                    "version": "4.0.11",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "async": "^1.4.0",
+                        "optimist": "^0.6.1",
+                        "source-map": "^0.4.4",
+                        "uglify-js": "^2.6"
+                    },
+                    "dependencies": {
+                        "source-map": {
+                            "version": "0.4.4",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "amdefine": ">=0.0.4"
+                            }
+                        }
+                    }
+                },
+                "has-ansi": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "has-value": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "get-value": "^2.0.6",
+                        "has-values": "^1.0.0",
+                        "isobject": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "isobject": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "has-values": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^3.0.0",
+                        "kind-of": "^4.0.0"
+                    },
+                    "dependencies": {
+                        "is-number": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "^1.1.5"
+                                    }
+                                }
+                            }
+                        },
+                        "kind-of": {
+                            "version": "4.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "hosted-git-info": {
+                    "version": "2.6.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "imurmurhash": {
+                    "version": "0.1.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "once": "^1.3.0",
+                        "wrappy": "1"
+                    }
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "invariant": {
+                    "version": "2.2.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "loose-envify": "^1.0.0"
+                    }
+                },
+                "invert-kv": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-accessor-descriptor": {
+                    "version": "0.1.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    }
+                },
+                "is-arrayish": {
+                    "version": "0.2.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-buffer": {
+                    "version": "1.1.6",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-builtin-module": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "builtin-modules": "^1.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "0.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "0.1.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "5.1.0",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "is-extendable": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-finite": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-number": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    }
+                },
+                "is-odd": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^4.0.0"
+                    },
+                    "dependencies": {
+                        "is-number": {
+                            "version": "4.0.0",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "is-plain-object": {
+                    "version": "2.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "isobject": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "isobject": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "is-stream": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-utf8": {
+                    "version": "0.2.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-windows": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "isexe": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "isobject": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "istanbul-lib-coverage": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "istanbul-lib-hook": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "append-transform": "^0.4.0"
+                    }
+                },
+                "istanbul-lib-instrument": {
+                    "version": "1.10.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "babel-generator": "^6.18.0",
+                        "babel-template": "^6.16.0",
+                        "babel-traverse": "^6.18.0",
+                        "babel-types": "^6.18.0",
+                        "babylon": "^6.18.0",
+                        "istanbul-lib-coverage": "^1.2.0",
+                        "semver": "^5.3.0"
+                    }
+                },
+                "istanbul-lib-report": {
+                    "version": "1.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "istanbul-lib-coverage": "^1.1.2",
+                        "mkdirp": "^0.5.1",
+                        "path-parse": "^1.0.5",
+                        "supports-color": "^3.1.2"
+                    },
+                    "dependencies": {
+                        "supports-color": {
+                            "version": "3.2.3",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "has-flag": "^1.0.0"
+                            }
+                        }
+                    }
+                },
+                "istanbul-lib-source-maps": {
+                    "version": "1.2.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "debug": "^3.1.0",
+                        "istanbul-lib-coverage": "^1.1.2",
+                        "mkdirp": "^0.5.1",
+                        "rimraf": "^2.6.1",
+                        "source-map": "^0.5.3"
+                    },
+                    "dependencies": {
+                        "debug": {
+                            "version": "3.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ms": "2.0.0"
+                            }
+                        }
+                    }
+                },
+                "istanbul-reports": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "handlebars": "^4.0.3"
+                    }
+                },
+                "js-tokens": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "jsesc": {
+                    "version": "1.3.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                },
+                "lazy-cache": {
+                    "version": "1.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "lcid": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "^1.0.0"
+                    }
+                },
+                "load-json-file": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^2.2.0",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0",
+                        "strip-bom": "^2.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "path-exists": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "lodash": {
+                    "version": "4.17.10",
+                    "bundled": true,
+                    "dev": true
+                },
+                "longest": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "loose-envify": {
+                    "version": "1.3.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "js-tokens": "^3.0.0"
+                    }
+                },
+                "lru-cache": {
+                    "version": "4.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
+                    }
+                },
+                "map-cache": {
+                    "version": "0.2.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "map-visit": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "object-visit": "^1.0.0"
+                    }
+                },
+                "md5-hex": {
+                    "version": "1.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "md5-o-matic": "^0.1.1"
+                    }
+                },
+                "md5-o-matic": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "mem": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "mimic-fn": "^1.0.0"
+                    }
+                },
+                "merge-source-map": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "source-map": "^0.6.1"
+                    },
+                    "dependencies": {
+                        "source-map": {
+                            "version": "0.6.1",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "6.0.2",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "mimic-fn": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
+                "minimist": {
+                    "version": "0.0.8",
+                    "bundled": true,
+                    "dev": true
+                },
+                "mixin-deep": {
+                    "version": "1.3.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "for-in": "^1.0.2",
+                        "is-extendable": "^1.0.1"
+                    },
+                    "dependencies": {
+                        "is-extendable": {
+                            "version": "1.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-plain-object": "^2.0.4"
+                            }
+                        }
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "nanomatch": {
+                    "version": "1.2.9",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "fragment-cache": "^0.2.1",
+                        "is-odd": "^2.0.0",
+                        "is-windows": "^1.0.2",
+                        "kind-of": "^6.0.2",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "arr-diff": {
+                            "version": "4.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "array-unique": {
+                            "version": "0.3.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "kind-of": {
+                            "version": "6.0.2",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "normalize-package-data": {
+                    "version": "2.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "hosted-git-info": "^2.1.4",
+                        "is-builtin-module": "^1.0.0",
+                        "semver": "2 || 3 || 4 || 5",
+                        "validate-npm-package-license": "^3.0.1"
+                    }
+                },
+                "npm-run-path": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^2.0.0"
+                    }
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "object-copy": {
+                    "version": "0.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "copy-descriptor": "^0.1.0",
+                        "define-property": "^0.2.5",
+                        "kind-of": "^3.0.3"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "0.2.5",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "object-visit": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "isobject": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "isobject": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "object.pick": {
+                    "version": "1.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "isobject": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "isobject": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "wrappy": "1"
+                    }
+                },
+                "optimist": {
+                    "version": "0.6.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minimist": "~0.0.1",
+                        "wordwrap": "~0.0.2"
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "os-locale": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "execa": "^0.7.0",
+                        "lcid": "^1.0.0",
+                        "mem": "^1.1.0"
+                    }
+                },
+                "p-finally": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "p-limit": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^1.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^1.1.0"
+                    }
+                },
+                "p-try": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "parse-json": {
+                    "version": "2.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "error-ex": "^1.2.0"
+                    }
+                },
+                "pascalcase": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-exists": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "pinkie-promise": "^2.0.0"
+                    }
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-key": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-parse": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-type": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.2",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
+                    }
+                },
+                "pify": {
+                    "version": "2.3.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "pinkie": {
+                    "version": "2.0.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "pinkie-promise": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "pinkie": "^2.0.0"
+                    }
+                },
+                "pkg-dir": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "find-up": {
+                            "version": "1.1.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "path-exists": "^2.0.0",
+                                "pinkie-promise": "^2.0.0"
+                            }
+                        }
+                    }
+                },
+                "posix-character-classes": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "pseudomap": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "read-pkg": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "load-json-file": "^1.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^1.0.0"
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^1.0.0",
+                        "read-pkg": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "find-up": {
+                            "version": "1.1.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "path-exists": "^2.0.0",
+                                "pinkie-promise": "^2.0.0"
+                            }
+                        }
+                    }
+                },
+                "regenerator-runtime": {
+                    "version": "0.11.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "regex-not": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "^3.0.2",
+                        "safe-regex": "^1.1.0"
+                    }
+                },
+                "repeat-element": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "repeat-string": {
+                    "version": "1.6.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "repeating": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-finite": "^1.0.0"
+                    }
+                },
+                "require-directory": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "require-main-filename": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "resolve-from": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "resolve-url": {
+                    "version": "0.2.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ret": {
+                    "version": "0.1.15",
+                    "bundled": true,
+                    "dev": true
+                },
+                "right-align": {
+                    "version": "0.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "align-text": "^0.1.1"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.6.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.0.5"
+                    }
+                },
+                "safe-regex": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ret": "~0.1.10"
+                    }
+                },
+                "semver": {
+                    "version": "5.5.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "set-value": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-extendable": "^0.1.1",
+                        "is-plain-object": "^2.0.3",
+                        "split-string": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "shebang-command": {
+                    "version": "1.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "shebang-regex": "^1.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "slide": {
+                    "version": "1.1.6",
+                    "bundled": true,
+                    "dev": true
+                },
+                "snapdragon": {
+                    "version": "0.8.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "base": "^0.11.1",
+                        "debug": "^2.2.0",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "map-cache": "^0.2.2",
+                        "source-map": "^0.5.6",
+                        "source-map-resolve": "^0.5.0",
+                        "use": "^3.1.0"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "0.2.5",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "^0.1.0"
+                            }
+                        },
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "snapdragon-node": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "define-property": "^1.0.0",
+                        "isobject": "^3.0.0",
+                        "snapdragon-util": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "^1.0.0"
+                            }
+                        },
+                        "is-accessor-descriptor": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^6.0.0"
+                            }
+                        },
+                        "is-data-descriptor": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^6.0.0"
+                            }
+                        },
+                        "is-descriptor": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-accessor-descriptor": "^1.0.0",
+                                "is-data-descriptor": "^1.0.0",
+                                "kind-of": "^6.0.2"
+                            }
+                        },
+                        "isobject": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "kind-of": {
+                            "version": "6.0.2",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "snapdragon-util": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.2.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "bundled": true,
+                    "dev": true
+                },
+                "source-map-resolve": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "atob": "^2.0.0",
+                        "decode-uri-component": "^0.2.0",
+                        "resolve-url": "^0.2.1",
+                        "source-map-url": "^0.4.0",
+                        "urix": "^0.1.0"
+                    }
+                },
+                "source-map-url": {
+                    "version": "0.4.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "spawn-wrap": {
+                    "version": "1.4.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "foreground-child": "^1.5.6",
+                        "mkdirp": "^0.5.0",
+                        "os-homedir": "^1.0.1",
+                        "rimraf": "^2.6.2",
+                        "signal-exit": "^3.0.2",
+                        "which": "^1.3.0"
+                    }
+                },
+                "spdx-correct": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "spdx-expression-parse": "^3.0.0",
+                        "spdx-license-ids": "^3.0.0"
+                    }
+                },
+                "spdx-exceptions": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "spdx-expression-parse": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "spdx-exceptions": "^2.1.0",
+                        "spdx-license-ids": "^3.0.0"
+                    }
+                },
+                "spdx-license-ids": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "split-string": {
+                    "version": "3.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "^3.0.0"
+                    }
+                },
+                "static-extend": {
+                    "version": "0.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "define-property": "^0.2.5",
+                        "object-copy": "^0.1.0"
+                    },
+                    "dependencies": {
+                        "define-property": {
+                            "version": "0.2.5",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-descriptor": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "strip-bom": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-utf8": "^0.2.0"
+                    }
+                },
+                "strip-eof": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "test-exclude": {
+                    "version": "4.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "arrify": "^1.0.1",
+                        "micromatch": "^3.1.8",
+                        "object-assign": "^4.1.0",
+                        "read-pkg-up": "^1.0.1",
+                        "require-main-filename": "^1.0.1"
+                    },
+                    "dependencies": {
+                        "arr-diff": {
+                            "version": "4.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "array-unique": {
+                            "version": "0.3.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "braces": {
+                            "version": "2.3.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "arr-flatten": "^1.1.0",
+                                "array-unique": "^0.3.2",
+                                "extend-shallow": "^2.0.1",
+                                "fill-range": "^4.0.0",
+                                "isobject": "^3.0.1",
+                                "repeat-element": "^1.1.2",
+                                "snapdragon": "^0.8.1",
+                                "snapdragon-node": "^2.0.1",
+                                "split-string": "^3.0.2",
+                                "to-regex": "^3.0.1"
+                            },
+                            "dependencies": {
+                                "extend-shallow": {
+                                    "version": "2.0.1",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "is-extendable": "^0.1.0"
+                                    }
+                                }
+                            }
+                        },
+                        "expand-brackets": {
+                            "version": "2.1.4",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "debug": "^2.3.3",
+                                "define-property": "^0.2.5",
+                                "extend-shallow": "^2.0.1",
+                                "posix-character-classes": "^0.1.0",
+                                "regex-not": "^1.0.0",
+                                "snapdragon": "^0.8.1",
+                                "to-regex": "^3.0.1"
+                            },
+                            "dependencies": {
+                                "define-property": {
+                                    "version": "0.2.5",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "is-descriptor": "^0.1.0"
+                                    }
+                                },
+                                "extend-shallow": {
+                                    "version": "2.0.1",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "is-extendable": "^0.1.0"
+                                    }
+                                },
+                                "is-accessor-descriptor": {
+                                    "version": "0.1.6",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "kind-of": "^3.0.2"
+                                    },
+                                    "dependencies": {
+                                        "kind-of": {
+                                            "version": "3.2.2",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "is-buffer": "^1.1.5"
+                                            }
+                                        }
+                                    }
+                                },
+                                "is-data-descriptor": {
+                                    "version": "0.1.4",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "kind-of": "^3.0.2"
+                                    },
+                                    "dependencies": {
+                                        "kind-of": {
+                                            "version": "3.2.2",
+                                            "bundled": true,
+                                            "dev": true,
+                                            "requires": {
+                                                "is-buffer": "^1.1.5"
+                                            }
+                                        }
+                                    }
+                                },
+                                "is-descriptor": {
+                                    "version": "0.1.6",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "is-accessor-descriptor": "^0.1.6",
+                                        "is-data-descriptor": "^0.1.4",
+                                        "kind-of": "^5.0.0"
+                                    }
+                                },
+                                "kind-of": {
+                                    "version": "5.1.0",
+                                    "bundled": true,
+                                    "dev": true
+                                }
+                            }
+                        },
+                        "extglob": {
+                            "version": "2.0.4",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "array-unique": "^0.3.2",
+                                "define-property": "^1.0.0",
+                                "expand-brackets": "^2.1.4",
+                                "extend-shallow": "^2.0.1",
+                                "fragment-cache": "^0.2.1",
+                                "regex-not": "^1.0.0",
+                                "snapdragon": "^0.8.1",
+                                "to-regex": "^3.0.1"
+                            },
+                            "dependencies": {
+                                "define-property": {
+                                    "version": "1.0.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "is-descriptor": "^1.0.0"
+                                    }
+                                },
+                                "extend-shallow": {
+                                    "version": "2.0.1",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "is-extendable": "^0.1.0"
+                                    }
+                                }
+                            }
+                        },
+                        "fill-range": {
+                            "version": "4.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "extend-shallow": "^2.0.1",
+                                "is-number": "^3.0.0",
+                                "repeat-string": "^1.6.1",
+                                "to-regex-range": "^2.1.0"
+                            },
+                            "dependencies": {
+                                "extend-shallow": {
+                                    "version": "2.0.1",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "is-extendable": "^0.1.0"
+                                    }
+                                }
+                            }
+                        },
+                        "is-accessor-descriptor": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^6.0.0"
+                            }
+                        },
+                        "is-data-descriptor": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^6.0.0"
+                            }
+                        },
+                        "is-descriptor": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-accessor-descriptor": "^1.0.0",
+                                "is-data-descriptor": "^1.0.0",
+                                "kind-of": "^6.0.2"
+                            }
+                        },
+                        "is-number": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "^1.1.5"
+                                    }
+                                }
+                            }
+                        },
+                        "isobject": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "kind-of": {
+                            "version": "6.0.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "micromatch": {
+                            "version": "3.1.10",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "arr-diff": "^4.0.0",
+                                "array-unique": "^0.3.2",
+                                "braces": "^2.3.1",
+                                "define-property": "^2.0.2",
+                                "extend-shallow": "^3.0.2",
+                                "extglob": "^2.0.4",
+                                "fragment-cache": "^0.2.1",
+                                "kind-of": "^6.0.2",
+                                "nanomatch": "^1.2.9",
+                                "object.pick": "^1.3.0",
+                                "regex-not": "^1.0.0",
+                                "snapdragon": "^0.8.1",
+                                "to-regex": "^3.0.2"
+                            }
+                        }
+                    }
+                },
+                "to-fast-properties": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "to-object-path": {
+                    "version": "0.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    }
+                },
+                "to-regex": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "regex-not": "^1.0.2",
+                        "safe-regex": "^1.1.0"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1"
+                    },
+                    "dependencies": {
+                        "is-number": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            }
+                        }
+                    }
+                },
+                "trim-right": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "uglify-js": {
+                    "version": "2.8.29",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "source-map": "~0.5.1",
+                        "uglify-to-browserify": "~1.0.0",
+                        "yargs": "~3.10.0"
+                    },
+                    "dependencies": {
+                        "yargs": {
+                            "version": "3.10.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true,
+                            "requires": {
+                                "camelcase": "^1.0.2",
+                                "cliui": "^2.1.0",
+                                "decamelize": "^1.0.0",
+                                "window-size": "0.1.0"
+                            }
+                        }
+                    }
+                },
+                "uglify-to-browserify": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "union-value": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "arr-union": "^3.1.0",
+                        "get-value": "^2.0.6",
+                        "is-extendable": "^0.1.1",
+                        "set-value": "^0.4.3"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        },
+                        "set-value": {
+                            "version": "0.4.3",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "extend-shallow": "^2.0.1",
+                                "is-extendable": "^0.1.1",
+                                "is-plain-object": "^2.0.1",
+                                "to-object-path": "^0.3.0"
+                            }
+                        }
+                    }
+                },
+                "unset-value": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "has-value": "^0.3.1",
+                        "isobject": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "has-value": {
+                            "version": "0.3.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "get-value": "^2.0.3",
+                                "has-values": "^0.1.4",
+                                "isobject": "^2.0.0"
+                            },
+                            "dependencies": {
+                                "isobject": {
+                                    "version": "2.1.0",
+                                    "bundled": true,
+                                    "dev": true,
+                                    "requires": {
+                                        "isarray": "1.0.0"
+                                    }
+                                }
+                            }
+                        },
+                        "has-values": {
+                            "version": "0.1.4",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "isobject": {
+                            "version": "3.0.1",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "urix": {
+                    "version": "0.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "use": {
+                    "version": "3.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "6.0.2",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "validate-npm-package-license": {
+                    "version": "3.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "spdx-correct": "^3.0.0",
+                        "spdx-expression-parse": "^3.0.0"
+                    }
+                },
+                "which": {
+                    "version": "1.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                },
+                "which-module": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "window-size": {
+                    "version": "0.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "wordwrap": {
+                    "version": "0.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "wrap-ansi": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "is-fullwidth-code-point": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "number-is-nan": "^1.0.0"
+                            }
+                        },
+                        "string-width": {
+                            "version": "1.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "write-file-atomic": {
+                    "version": "1.3.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.11",
+                        "imurmurhash": "^0.1.4",
+                        "slide": "^1.1.5"
+                    }
+                },
+                "y18n": {
+                    "version": "3.2.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "yallist": {
+                    "version": "2.1.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "11.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.1.1",
+                        "find-up": "^2.1.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^2.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^9.0.2"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "camelcase": {
+                            "version": "4.1.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "cliui": {
+                            "version": "4.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "string-width": "^2.1.1",
+                                "strip-ansi": "^4.0.0",
+                                "wrap-ansi": "^2.0.0"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^3.0.0"
+                            }
+                        },
+                        "yargs-parser": {
+                            "version": "9.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "camelcase": "^4.1.0"
+                            }
+                        }
+                    }
+                },
+                "yargs-parser": {
+                    "version": "8.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^4.1.0"
+                    },
+                    "dependencies": {
+                        "camelcase": {
+                            "version": "4.1.0",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                }
+            }
+        },
+        "oauth-sign": {
+            "version": "0.9.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/oauth-sign/-/oauth-sign-0.9.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Foauth-sign%2F-%2Foauth-sign-0.9.0.tgz",
+            "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU="
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/object-assign/-/object-assign-4.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fobject-assign%2F-%2Fobject-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "object-hash": {
+            "version": "1.3.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/object-hash/-/object-hash-1.3.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fobject-hash%2F-%2Fobject-hash-1.3.1.tgz",
+            "integrity": "sha1-/eRSCYqVHLFF8Dm7fUVUSd3BJt8="
+        },
+        "oidc-token-hash": {
+            "version": "3.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/oidc-token-hash/-/oidc-token-hash-3.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Foidc-token-hash%2F-%2Foidc-token-hash-3.0.2.tgz",
+            "integrity": "sha1-W9RxbMSK1DP05OmSdoEQGbFlaX4="
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/once/-/once-1.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fonce%2F-%2Fonce-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "onetime": {
+            "version": "2.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/onetime/-/onetime-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fonetime%2F-%2Fonetime-2.0.1.tgz",
+            "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+            "dev": true,
+            "requires": {
+                "mimic-fn": "^1.0.0"
+            }
+        },
+        "opener": {
+            "version": "1.5.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/opener/-/opener-1.5.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fopener%2F-%2Fopener-1.5.1.tgz",
+            "integrity": "sha1-bS8Od/GgrwAyrKcWwsH7uOfoq+0=",
+            "dev": true
+        },
+        "openid-client": {
+            "version": "2.5.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/openid-client/-/openid-client-2.5.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fopenid-client%2F-%2Fopenid-client-2.5.0.tgz",
+            "integrity": "sha1-fUz1UrMNutJpF9ficiQi7aBX6pM=",
+            "requires": {
+                "base64url": "^3.0.0",
+                "got": "^8.3.2",
+                "lodash": "^4.17.11",
+                "lru-cache": "^5.1.1",
+                "node-jose": "^1.1.0",
+                "object-hash": "^1.3.1",
+                "oidc-token-hash": "^3.0.1",
+                "p-any": "^1.1.0"
+            }
+        },
+        "optimist": {
+            "version": "0.6.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/optimist/-/optimist-0.6.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Foptimist%2F-%2Foptimist-0.6.1.tgz",
+            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+            "dev": true,
+            "requires": {
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.10",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/minimist/-/minimist-0.0.10.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fminimist%2F-%2Fminimist-0.0.10.tgz",
+                    "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+                    "dev": true
+                },
+                "wordwrap": {
+                    "version": "0.0.3",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/wordwrap/-/wordwrap-0.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwordwrap%2F-%2Fwordwrap-0.0.3.tgz",
+                    "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+                    "dev": true
+                }
+            }
+        },
+        "optionator": {
+            "version": "0.8.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/optionator/-/optionator-0.8.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Foptionator%2F-%2Foptionator-0.8.2.tgz",
+            "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+            "dev": true,
+            "requires": {
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
+            }
+        },
+        "os-homedir": {
+            "version": "1.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/os-homedir/-/os-homedir-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fos-homedir%2F-%2Fos-homedir-1.0.2.tgz",
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+            "dev": true
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/os-tmpdir/-/os-tmpdir-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fos-tmpdir%2F-%2Fos-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true
+        },
+        "own-or": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/own-or/-/own-or-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fown-or%2F-%2Fown-or-1.0.0.tgz",
+            "integrity": "sha1-Tod/vtqaLsgAD7wLyuOWRe6L+Nw=",
+            "dev": true
+        },
+        "own-or-env": {
+            "version": "1.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/own-or-env/-/own-or-env-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fown-or-env%2F-%2Fown-or-env-1.0.1.tgz",
+            "integrity": "sha1-VM5gHTv3gjbFxlYzqhyOwD+AB+Q=",
+            "dev": true,
+            "requires": {
+                "own-or": "^1.0.0"
+            }
+        },
+        "p-any": {
+            "version": "1.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/p-any/-/p-any-1.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-any%2F-%2Fp-any-1.1.0.tgz",
+            "integrity": "sha1-HQODXH7tHjS45TnEe3tg0NAV1OE=",
+            "requires": {
+                "p-some": "^2.0.0"
+            }
+        },
+        "p-cancelable": {
+            "version": "0.4.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/p-cancelable/-/p-cancelable-0.4.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-cancelable%2F-%2Fp-cancelable-0.4.1.tgz",
+            "integrity": "sha1-NfNj1n1SCByNlYXje8zrfgu8sqA="
+        },
+        "p-finally": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/p-finally/-/p-finally-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-finally%2F-%2Fp-finally-1.0.0.tgz",
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+        },
+        "p-is-promise": {
+            "version": "1.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/p-is-promise/-/p-is-promise-1.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-is-promise%2F-%2Fp-is-promise-1.1.0.tgz",
+            "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
+        },
+        "p-limit": {
+            "version": "2.2.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/p-limit/-/p-limit-2.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-limit%2F-%2Fp-limit-2.2.1.tgz",
+            "integrity": "sha1-qgeniMwxUck5tRMfY1cPDdIAlTc=",
+            "dev": true,
+            "requires": {
+                "p-try": "^2.0.0"
+            }
+        },
+        "p-locate": {
+            "version": "3.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/p-locate/-/p-locate-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-locate%2F-%2Fp-locate-3.0.0.tgz",
+            "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+            "dev": true,
+            "requires": {
+                "p-limit": "^2.0.0"
+            }
+        },
+        "p-some": {
+            "version": "2.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/p-some/-/p-some-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-some%2F-%2Fp-some-2.0.1.tgz",
+            "integrity": "sha1-Zdh8ixVO289SIdFnd4ttLhUPbwY=",
+            "requires": {
+                "aggregate-error": "^1.0.0"
+            }
+        },
+        "p-timeout": {
+            "version": "2.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/p-timeout/-/p-timeout-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-timeout%2F-%2Fp-timeout-2.0.1.tgz",
+            "integrity": "sha1-2N0ZeVldLcATnh/ka4tkbLPN8Dg=",
+            "requires": {
+                "p-finally": "^1.0.0"
+            }
+        },
+        "p-try": {
+            "version": "2.2.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/p-try/-/p-try-2.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fp-try%2F-%2Fp-try-2.2.0.tgz",
+            "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
+            "dev": true
+        },
+        "package-hash": {
+            "version": "3.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/package-hash/-/package-hash-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpackage-hash%2F-%2Fpackage-hash-3.0.0.tgz",
+            "integrity": "sha1-UBg/LTbJ4+Uo6gqGBd/1fOl2+I4=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.15",
+                "hasha": "^3.0.0",
+                "lodash.flattendeep": "^4.4.0",
+                "release-zalgo": "^1.0.0"
+            }
+        },
+        "parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/parent-module/-/parent-module-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fparent-module%2F-%2Fparent-module-1.0.1.tgz",
+            "integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
+            "dev": true,
+            "requires": {
+                "callsites": "^3.0.0"
+            }
+        },
+        "parse-json": {
+            "version": "4.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/parse-json/-/parse-json-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fparse-json%2F-%2Fparse-json-4.0.0.tgz",
+            "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+            "dev": true,
+            "requires": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+            }
+        },
+        "path-exists": {
+            "version": "3.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/path-exists/-/path-exists-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpath-exists%2F-%2Fpath-exists-3.0.0.tgz",
+            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/path-is-absolute/-/path-is-absolute-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpath-is-absolute%2F-%2Fpath-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "path-key": {
+            "version": "2.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/path-key/-/path-key-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpath-key%2F-%2Fpath-key-2.0.1.tgz",
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.6",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/path-parse/-/path-parse-1.0.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpath-parse%2F-%2Fpath-parse-1.0.6.tgz",
+            "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw="
+        },
+        "path-type": {
+            "version": "3.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/path-type/-/path-type-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpath-type%2F-%2Fpath-type-3.0.0.tgz",
+            "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
+            "dev": true,
+            "requires": {
+                "pify": "^3.0.0"
+            }
+        },
+        "performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/performance-now/-/performance-now-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fperformance-now%2F-%2Fperformance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+        },
+        "picomatch": {
+            "version": "2.0.7",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/picomatch/-/picomatch-2.0.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpicomatch%2F-%2Fpicomatch-2.0.7.tgz",
+            "integrity": "sha1-UUFp2MfNC9vuzIomCeNKcWPeafY=",
+            "dev": true
+        },
+        "pify": {
+            "version": "3.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/pify/-/pify-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpify%2F-%2Fpify-3.0.0.tgz",
+            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        },
+        "pirates": {
+            "version": "3.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/pirates/-/pirates-3.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpirates%2F-%2Fpirates-3.0.2.tgz",
+            "integrity": "sha1-fm+FQT/ZFhq04StTmwYBDYWVS7k=",
+            "dev": true,
+            "requires": {
+                "node-modules-regexp": "^1.0.0"
+            }
+        },
+        "pkg-dir": {
+            "version": "3.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/pkg-dir/-/pkg-dir-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpkg-dir%2F-%2Fpkg-dir-3.0.0.tgz",
+            "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
+            "dev": true,
+            "requires": {
+                "find-up": "^3.0.0"
+            }
+        },
+        "prelude-ls": {
+            "version": "1.1.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/prelude-ls/-/prelude-ls-1.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fprelude-ls%2F-%2Fprelude-ls-1.1.2.tgz",
+            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+            "dev": true
+        },
+        "prepend-http": {
+            "version": "2.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/prepend-http/-/prepend-http-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fprepend-http%2F-%2Fprepend-http-2.0.0.tgz",
+            "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+        },
+        "process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/process-nextick-args/-/process-nextick-args-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fprocess-nextick-args%2F-%2Fprocess-nextick-args-2.0.1.tgz",
+            "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
+        },
+        "progress": {
+            "version": "2.0.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/progress/-/progress-2.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fprogress%2F-%2Fprogress-2.0.3.tgz",
+            "integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg=",
+            "dev": true
+        },
+        "properties": {
+            "version": "1.2.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/properties/-/properties-1.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fproperties%2F-%2Fproperties-1.2.1.tgz",
+            "integrity": "sha1-Dul6f8AgsaKlW4ZZ7aSqjYaQlL0="
+        },
+        "pseudomap": {
+            "version": "1.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/pseudomap/-/pseudomap-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpseudomap%2F-%2Fpseudomap-1.0.2.tgz",
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+            "dev": true
+        },
+        "psl": {
+            "version": "1.3.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/psl/-/psl-1.3.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpsl%2F-%2Fpsl-1.3.1.tgz",
+            "integrity": "sha1-1ao4c6NexFC8fbkBKtWnJG9vyL0="
+        },
+        "pump": {
+            "version": "3.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/pump/-/pump-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpump%2F-%2Fpump-3.0.0.tgz",
+            "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
+        "punycode": {
+            "version": "2.1.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/punycode/-/punycode-2.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpunycode%2F-%2Fpunycode-2.1.1.tgz",
+            "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
+        },
+        "qs": {
+            "version": "6.8.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/qs/-/qs-6.8.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fqs%2F-%2Fqs-6.8.0.tgz",
+            "integrity": "sha1-h7dj8NN8pUIAM0zVe7Lvj2ih0IE="
+        },
+        "query-string": {
+            "version": "5.1.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/query-string/-/query-string-5.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fquery-string%2F-%2Fquery-string-5.1.1.tgz",
+            "integrity": "sha1-p4wBK3HBfgXy4/ojGd0zBoLvs8s=",
+            "requires": {
+                "decode-uri-component": "^0.2.0",
+                "object-assign": "^4.1.0",
+                "strict-uri-encode": "^1.0.0"
+            }
+        },
+        "re-emitter": {
+            "version": "1.1.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/re-emitter/-/re-emitter-1.1.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fre-emitter%2F-%2Fre-emitter-1.1.3.tgz",
+            "integrity": "sha1-+p4xn/3u6zWycpbvDz03TawvUqc=",
+            "dev": true
+        },
+        "read-pkg": {
+            "version": "3.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/read-pkg/-/read-pkg-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fread-pkg%2F-%2Fread-pkg-3.0.0.tgz",
+            "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+            "dev": true,
+            "requires": {
+                "load-json-file": "^4.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^3.0.0"
+            }
+        },
+        "read-pkg-up": {
+            "version": "4.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/read-pkg-up/-/read-pkg-up-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fread-pkg-up%2F-%2Fread-pkg-up-4.0.0.tgz",
+            "integrity": "sha1-GyIcYIi6d5lgHICPkRYcZuWPiXg=",
+            "dev": true,
+            "requires": {
+                "find-up": "^3.0.0",
+                "read-pkg": "^3.0.0"
+            }
+        },
+        "readable-stream": {
+            "version": "2.3.6",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/readable-stream/-/readable-stream-2.3.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Freadable-stream%2F-%2Freadable-stream-2.3.6.tgz",
+            "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
+            "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            },
+            "dependencies": {
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/safe-buffer/-/safe-buffer-5.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsafe-buffer%2F-%2Fsafe-buffer-5.1.2.tgz",
+                    "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+                }
+            }
+        },
+        "readdirp": {
+            "version": "3.1.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/readdirp/-/readdirp-3.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Freaddirp%2F-%2Freaddirp-3.1.2.tgz",
+            "integrity": "sha1-+oXS0U1CiZIORnHerZZDGt0u54o=",
+            "dev": true,
+            "requires": {
+                "picomatch": "^2.0.4"
+            }
+        },
+        "rechoir": {
+            "version": "0.6.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/rechoir/-/rechoir-0.6.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Frechoir%2F-%2Frechoir-0.6.2.tgz",
+            "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+            "requires": {
+                "resolve": "^1.1.6"
+            }
+        },
+        "regenerator-runtime": {
+            "version": "0.11.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fregenerator-runtime%2F-%2Fregenerator-runtime-0.11.1.tgz",
+            "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk=",
+            "dev": true
+        },
+        "regexpp": {
+            "version": "2.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/regexpp/-/regexpp-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fregexpp%2F-%2Fregexpp-2.0.1.tgz",
+            "integrity": "sha1-jRnTHPYySCtYkEn4KB+T28uk0H8=",
+            "dev": true
+        },
+        "release-zalgo": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/release-zalgo/-/release-zalgo-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Frelease-zalgo%2F-%2Frelease-zalgo-1.0.0.tgz",
+            "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+            "dev": true,
+            "requires": {
+                "es6-error": "^4.0.1"
+            }
+        },
+        "repeating": {
+            "version": "1.1.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/repeating/-/repeating-1.1.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Frepeating%2F-%2Frepeating-1.1.3.tgz",
+            "integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
+            "dev": true,
+            "requires": {
+                "is-finite": "^1.0.0"
+            }
+        },
+        "request": {
+            "version": "2.88.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/request/-/request-2.88.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Frequest%2F-%2Frequest-2.88.0.tgz",
+            "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
+            "requires": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.0",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.4.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
+            },
+            "dependencies": {
+                "form-data": {
+                    "version": "2.3.3",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/form-data/-/form-data-2.3.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fform-data%2F-%2Fform-data-2.3.3.tgz",
+                    "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.6",
+                        "mime-types": "^2.1.12"
+                    }
+                },
+                "qs": {
+                    "version": "6.5.2",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/qs/-/qs-6.5.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fqs%2F-%2Fqs-6.5.2.tgz",
+                    "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY="
+                },
+                "uuid": {
+                    "version": "3.3.3",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/uuid/-/uuid-3.3.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fuuid%2F-%2Fuuid-3.3.3.tgz",
+                    "integrity": "sha1-RWjwIW54dg7h2/Ok0s9T4iQRKGY="
+                }
+            }
+        },
+        "require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/require-directory/-/require-directory-2.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Frequire-directory%2F-%2Frequire-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true
+        },
+        "require-main-filename": {
+            "version": "2.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/require-main-filename/-/require-main-filename-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Frequire-main-filename%2F-%2Frequire-main-filename-2.0.0.tgz",
+            "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
+            "dev": true
+        },
+        "resolve": {
+            "version": "1.12.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/resolve/-/resolve-1.12.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fresolve%2F-%2Fresolve-1.12.0.tgz",
+            "integrity": "sha1-P8ZEo1yEpIVUYJ/ybsUrZvpXffY=",
+            "requires": {
+                "path-parse": "^1.0.6"
+            }
+        },
+        "resolve-from": {
+            "version": "4.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/resolve-from/-/resolve-from-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fresolve-from%2F-%2Fresolve-from-4.0.0.tgz",
+            "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
+            "dev": true
+        },
+        "responselike": {
+            "version": "1.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/responselike/-/responselike-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fresponselike%2F-%2Fresponselike-1.0.2.tgz",
+            "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+            "requires": {
+                "lowercase-keys": "^1.0.0"
+            }
+        },
+        "restore-cursor": {
+            "version": "2.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/restore-cursor/-/restore-cursor-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Frestore-cursor%2F-%2Frestore-cursor-2.0.0.tgz",
+            "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+            "dev": true,
+            "requires": {
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
+            }
+        },
+        "rimraf": {
+            "version": "2.6.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/rimraf/-/rimraf-2.6.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Frimraf%2F-%2Frimraf-2.6.3.tgz",
+            "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3"
+            }
+        },
+        "run-async": {
+            "version": "2.3.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/run-async/-/run-async-2.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Frun-async%2F-%2Frun-async-2.3.0.tgz",
+            "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+            "dev": true,
+            "requires": {
+                "is-promise": "^2.1.0"
+            }
+        },
+        "rxjs": {
+            "version": "6.5.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/rxjs/-/rxjs-6.5.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Frxjs%2F-%2Frxjs-6.5.2.tgz",
+            "integrity": "sha1-LjXOgVzUbYTQKiCftOWSHgUdvsc=",
+            "dev": true,
+            "requires": {
+                "tslib": "^1.9.0"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.2.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/safe-buffer/-/safe-buffer-5.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsafe-buffer%2F-%2Fsafe-buffer-5.2.0.tgz",
+            "integrity": "sha1-t02uxJsRSPiMZLaNSbHoFcHy9Rk="
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/safer-buffer/-/safer-buffer-2.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsafer-buffer%2F-%2Fsafer-buffer-2.1.2.tgz",
+            "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
+        },
+        "semver": {
+            "version": "4.3.6",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/semver/-/semver-4.3.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsemver%2F-%2Fsemver-4.3.6.tgz",
+            "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
+        },
+        "set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/set-blocking/-/set-blocking-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fset-blocking%2F-%2Fset-blocking-2.0.0.tgz",
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
+        },
+        "shallow-clone": {
+            "version": "0.1.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/shallow-clone/-/shallow-clone-0.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fshallow-clone%2F-%2Fshallow-clone-0.1.2.tgz",
+            "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
+            "requires": {
+                "is-extendable": "^0.1.1",
+                "kind-of": "^2.0.1",
+                "lazy-cache": "^0.2.3",
+                "mixin-object": "^2.0.1"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "2.0.1",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/kind-of/-/kind-of-2.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fkind-of%2F-%2Fkind-of-2.0.1.tgz",
+                    "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
+                    "requires": {
+                        "is-buffer": "^1.0.2"
+                    }
+                },
+                "lazy-cache": {
+                    "version": "0.2.7",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/lazy-cache/-/lazy-cache-0.2.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Flazy-cache%2F-%2Flazy-cache-0.2.7.tgz",
+                    "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
+                }
+            }
+        },
+        "shebang-command": {
+            "version": "1.2.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/shebang-command/-/shebang-command-1.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fshebang-command%2F-%2Fshebang-command-1.2.0.tgz",
+            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "dev": true,
+            "requires": {
+                "shebang-regex": "^1.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/shebang-regex/-/shebang-regex-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fshebang-regex%2F-%2Fshebang-regex-1.0.0.tgz",
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+            "dev": true
+        },
+        "shelljs": {
+            "version": "0.8.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/shelljs/-/shelljs-0.8.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fshelljs%2F-%2Fshelljs-0.8.3.tgz",
+            "integrity": "sha1-p/MxlSDr8J7oEnWyNorbKGZZsJc=",
+            "requires": {
+                "glob": "^7.0.0",
+                "interpret": "^1.0.0",
+                "rechoir": "^0.6.2"
+            }
+        },
+        "should": {
+            "version": "9.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/should/-/should-9.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fshould%2F-%2Fshould-9.0.2.tgz",
+            "integrity": "sha1-tVD2keccZniODpbp9yHVi+aSDlo=",
+            "dev": true,
+            "requires": {
+                "should-equal": "^1.0.0",
+                "should-format": "^1.0.0",
+                "should-type": "^1.0.0"
+            }
+        },
+        "should-equal": {
+            "version": "1.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/should-equal/-/should-equal-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fshould-equal%2F-%2Fshould-equal-1.0.1.tgz",
+            "integrity": "sha1-C26VFvJgGp+wuy3MNpr6HH4gCvc=",
+            "dev": true,
+            "requires": {
+                "should-type": "^1.0.0"
+            }
+        },
+        "should-format": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/should-format/-/should-format-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fshould-format%2F-%2Fshould-format-1.0.0.tgz",
+            "integrity": "sha1-CjDNq0o70UJ7vMuLc4VnvacpDXg=",
+            "dev": true,
+            "requires": {
+                "should-type": "^1.0.0"
+            }
+        },
+        "should-http": {
+            "version": "0.0.4",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/should-http/-/should-http-0.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fshould-http%2F-%2Fshould-http-0.0.4.tgz",
+            "integrity": "sha1-sqOaR4D5DZsji66st71MTz/H2kk=",
+            "dev": true
+        },
+        "should-type": {
+            "version": "1.4.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/should-type/-/should-type-1.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fshould-type%2F-%2Fshould-type-1.4.0.tgz",
+            "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM=",
+            "dev": true
+        },
+        "signal-exit": {
+            "version": "3.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/signal-exit/-/signal-exit-3.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsignal-exit%2F-%2Fsignal-exit-3.0.2.tgz",
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+            "dev": true
+        },
+        "slice-ansi": {
+            "version": "2.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/slice-ansi/-/slice-ansi-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fslice-ansi%2F-%2Fslice-ansi-2.1.0.tgz",
+            "integrity": "sha1-ys12k0YaY3pXiNkqfdT7oGjoFjY=",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^3.2.0",
+                "astral-regex": "^1.0.0",
+                "is-fullwidth-code-point": "^2.0.0"
+            }
+        },
+        "sort-keys": {
+            "version": "2.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/sort-keys/-/sort-keys-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsort-keys%2F-%2Fsort-keys-2.0.0.tgz",
+            "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+            "requires": {
+                "is-plain-obj": "^1.0.0"
+            }
+        },
+        "source-map": {
+            "version": "0.6.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/source-map/-/source-map-0.6.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsource-map%2F-%2Fsource-map-0.6.1.tgz",
+            "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+            "dev": true
+        },
+        "source-map-support": {
+            "version": "0.5.13",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/source-map-support/-/source-map-support-0.5.13.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsource-map-support%2F-%2Fsource-map-support-0.5.13.tgz",
+            "integrity": "sha1-MbJKnC5zwt6FBmwP631Edn7VKTI=",
+            "dev": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            }
+        },
+        "spawn-wrap": {
+            "version": "1.4.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/spawn-wrap/-/spawn-wrap-1.4.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fspawn-wrap%2F-%2Fspawn-wrap-1.4.3.tgz",
+            "integrity": "sha1-gbdnDhcMyiR9gL9frwz7cTvc+Eg=",
+            "dev": true,
+            "requires": {
+                "foreground-child": "^1.5.6",
+                "mkdirp": "^0.5.0",
+                "os-homedir": "^1.0.1",
+                "rimraf": "^2.6.2",
+                "signal-exit": "^3.0.2",
+                "which": "^1.3.0"
+            }
+        },
+        "spdx-correct": {
+            "version": "3.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/spdx-correct/-/spdx-correct-3.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fspdx-correct%2F-%2Fspdx-correct-3.1.0.tgz",
+            "integrity": "sha1-+4PlBERSaPFUsHTiGMh8ADzTHfQ=",
+            "dev": true,
+            "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-exceptions": {
+            "version": "2.2.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fspdx-exceptions%2F-%2Fspdx-exceptions-2.2.0.tgz",
+            "integrity": "sha1-LqRQrudPKom/uUUZwH/Nb0EyKXc=",
+            "dev": true
+        },
+        "spdx-expression-parse": {
+            "version": "3.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fspdx-expression-parse%2F-%2Fspdx-expression-parse-3.0.0.tgz",
+            "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
+            "dev": true,
+            "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-license-ids": {
+            "version": "3.0.5",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fspdx-license-ids%2F-%2Fspdx-license-ids-3.0.5.tgz",
+            "integrity": "sha1-NpS1gEVnpFjTyARYQqY1hjL2JlQ=",
+            "dev": true
+        },
+        "split": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/split/-/split-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsplit%2F-%2Fsplit-1.0.0.tgz",
+            "integrity": "sha1-xDlc5oOrzSVLwo/h2rtuXCfc/64=",
+            "dev": true,
+            "requires": {
+                "through": "2"
+            }
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/sprintf-js/-/sprintf-js-1.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsprintf-js%2F-%2Fsprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+        },
+        "sshpk": {
+            "version": "1.16.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/sshpk/-/sshpk-1.16.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsshpk%2F-%2Fsshpk-1.16.1.tgz",
+            "integrity": "sha1-+2YcC+8ps520B2nuOfpwCT1vaHc=",
+            "requires": {
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
+            }
+        },
+        "stack-utils": {
+            "version": "1.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/stack-utils/-/stack-utils-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstack-utils%2F-%2Fstack-utils-1.0.2.tgz",
+            "integrity": "sha1-M+ujiXeIVYvr/C2wWdwVjsNs67g=",
+            "dev": true
+        },
+        "strict-uri-encode": {
+            "version": "1.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstrict-uri-encode%2F-%2Fstrict-uri-encode-1.1.0.tgz",
+            "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+        },
+        "string-width": {
+            "version": "2.1.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/string-width/-/string-width-2.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstring-width%2F-%2Fstring-width-2.1.1.tgz",
+            "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+            "dev": true,
+            "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/ansi-regex/-/ansi-regex-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-regex%2F-%2Fansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/strip-ansi/-/strip-ansi-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstrip-ansi%2F-%2Fstrip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/string_decoder/-/string_decoder-1.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstring_decoder%2F-%2Fstring_decoder-1.1.1.tgz",
+            "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+            "requires": {
+                "safe-buffer": "~5.1.0"
+            },
+            "dependencies": {
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/safe-buffer/-/safe-buffer-5.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsafe-buffer%2F-%2Fsafe-buffer-5.1.2.tgz",
+                    "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+                }
+            }
+        },
+        "strip-ansi": {
+            "version": "4.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/strip-ansi/-/strip-ansi-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstrip-ansi%2F-%2Fstrip-ansi-4.0.0.tgz",
+            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^3.0.0"
+            }
+        },
+        "strip-bom": {
+            "version": "3.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/strip-bom/-/strip-bom-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstrip-bom%2F-%2Fstrip-bom-3.0.0.tgz",
+            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+            "dev": true
+        },
+        "strip-json-comments": {
+            "version": "3.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/strip-json-comments/-/strip-json-comments-3.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstrip-json-comments%2F-%2Fstrip-json-comments-3.0.1.tgz",
+            "integrity": "sha1-hXE5dakfuHvxswXMp3OV5A0qZKc=",
+            "dev": true
+        },
+        "supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/supports-color/-/supports-color-5.5.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsupports-color%2F-%2Fsupports-color-5.5.0.tgz",
+            "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+            "dev": true,
+            "requires": {
+                "has-flag": "^3.0.0"
+            },
+            "dependencies": {
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/has-flag/-/has-flag-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fhas-flag%2F-%2Fhas-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                }
+            }
+        },
+        "swagger-fluent": {
+            "version": "3.2.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/swagger-fluent/-/swagger-fluent-3.2.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fswagger-fluent%2F-%2Fswagger-fluent-3.2.1.tgz",
+            "integrity": "sha1-dV1GF8109MMMJQE8clJpvcuwxZk=",
+            "requires": {
+                "merge-deep": "^3.0.2",
+                "request": "^2.88.0"
+            }
+        },
+        "table": {
+            "version": "5.4.6",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/table/-/table-5.4.6.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftable%2F-%2Ftable-5.4.6.tgz",
+            "integrity": "sha1-EpLRlQDOP4YFOwXw6Ofko7shB54=",
+            "dev": true,
+            "requires": {
+                "ajv": "^6.10.2",
+                "lodash": "^4.17.14",
+                "slice-ansi": "^2.1.0",
+                "string-width": "^3.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/ansi-regex/-/ansi-regex-4.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-regex%2F-%2Fansi-regex-4.1.0.tgz",
+                    "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/string-width/-/string-width-3.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstring-width%2F-%2Fstring-width-3.1.0.tgz",
+                    "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/strip-ansi/-/strip-ansi-5.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstrip-ansi%2F-%2Fstrip-ansi-5.2.0.tgz",
+                    "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                }
+            }
+        },
+        "tap": {
+            "version": "14.6.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/tap/-/tap-14.6.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftap%2F-%2Ftap-14.6.1.tgz",
+            "integrity": "sha1-rZSiuqWmHbdy+votFyuo33cymmw=",
+            "dev": true,
+            "requires": {
+                "async-hook-domain": "^1.1.0",
+                "bind-obj-methods": "^2.0.0",
+                "browser-process-hrtime": "^1.0.0",
+                "capture-stack-trace": "^1.0.0",
+                "chokidar": "^3.0.2",
+                "color-support": "^1.1.0",
+                "coveralls": "^3.0.5",
+                "diff": "^4.0.1",
+                "esm": "^3.2.25",
+                "findit": "^2.0.0",
+                "flow-remove-types": "^2.101.0",
+                "foreground-child": "^1.3.3",
+                "fs-exists-cached": "^1.0.0",
+                "function-loop": "^1.0.2",
+                "glob": "^7.1.4",
+                "import-jsx": "^2.0.0",
+                "ink": "^2.3.0",
+                "isexe": "^2.0.0",
+                "istanbul-lib-processinfo": "^1.0.0",
+                "jackspeak": "^1.4.0",
+                "minipass": "^2.3.5",
+                "mkdirp": "^0.5.1",
+                "nyc": "^14.1.1",
+                "opener": "^1.5.1",
+                "own-or": "^1.0.0",
+                "own-or-env": "^1.0.1",
+                "react": "^16.8.6",
+                "rimraf": "^2.6.3",
+                "signal-exit": "^3.0.0",
+                "source-map-support": "^0.5.12",
+                "stack-utils": "^1.0.2",
+                "tap-mocha-reporter": "^4.0.1",
+                "tap-parser": "^9.3.2",
+                "tap-yaml": "^1.0.0",
+                "tcompare": "^2.3.0",
+                "treport": "^0.4.0",
+                "trivial-deferred": "^1.0.1",
+                "ts-node": "^8.3.0",
+                "typescript": "^3.5.3",
+                "which": "^1.3.1",
+                "write-file-atomic": "^3.0.0",
+                "yaml": "^1.6.0",
+                "yapool": "^1.0.0"
+            },
+            "dependencies": {
+                "@babel/runtime": {
+                    "version": "7.4.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "regenerator-runtime": "^0.13.2"
+                    },
+                    "dependencies": {
+                        "regenerator-runtime": {
+                            "version": "0.13.2",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "@types/prop-types": {
+                    "version": "15.7.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "@types/react": {
+                    "version": "16.8.22",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@types/prop-types": "*",
+                        "csstype": "^2.2.0"
+                    }
+                },
+                "ansi-escapes": {
+                    "version": "3.2.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ansicolors": {
+                    "version": "0.3.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "arrify": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "astral-regex": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "auto-bind": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@types/react": "^16.8.12"
+                    }
+                },
+                "babel-code-frame": {
+                    "version": "6.26.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^1.1.3",
+                        "esutils": "^2.0.2",
+                        "js-tokens": "^3.0.2"
+                    }
+                },
+                "babel-core": {
+                    "version": "6.26.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "babel-code-frame": "^6.26.0",
+                        "babel-generator": "^6.26.0",
+                        "babel-helpers": "^6.24.1",
+                        "babel-messages": "^6.23.0",
+                        "babel-register": "^6.26.0",
+                        "babel-runtime": "^6.26.0",
+                        "babel-template": "^6.26.0",
+                        "babel-traverse": "^6.26.0",
+                        "babel-types": "^6.26.0",
+                        "babylon": "^6.18.0",
+                        "convert-source-map": "^1.5.1",
+                        "debug": "^2.6.9",
+                        "json5": "^0.5.1",
+                        "lodash": "^4.17.4",
+                        "minimatch": "^3.0.4",
+                        "path-is-absolute": "^1.0.1",
+                        "private": "^0.1.8",
+                        "slash": "^1.0.0",
+                        "source-map": "^0.5.7"
+                    },
+                    "dependencies": {
+                        "source-map": {
+                            "version": "0.5.7",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "babel-generator": {
+                    "version": "6.26.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "babel-messages": "^6.23.0",
+                        "babel-runtime": "^6.26.0",
+                        "babel-types": "^6.26.0",
+                        "detect-indent": "^4.0.0",
+                        "jsesc": "^1.3.0",
+                        "lodash": "^4.17.4",
+                        "source-map": "^0.5.7",
+                        "trim-right": "^1.0.1"
+                    },
+                    "dependencies": {
+                        "source-map": {
+                            "version": "0.5.7",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "babel-helper-builder-react-jsx": {
+                    "version": "6.26.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "^6.26.0",
+                        "babel-types": "^6.26.0",
+                        "esutils": "^2.0.2"
+                    }
+                },
+                "babel-helpers": {
+                    "version": "6.24.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "^6.22.0",
+                        "babel-template": "^6.24.1"
+                    }
+                },
+                "babel-messages": {
+                    "version": "6.23.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "^6.22.0"
+                    }
+                },
+                "babel-plugin-syntax-jsx": {
+                    "version": "6.18.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "babel-plugin-syntax-object-rest-spread": {
+                    "version": "6.13.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "babel-plugin-transform-es2015-destructuring": {
+                    "version": "6.23.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "^6.22.0"
+                    }
+                },
+                "babel-plugin-transform-object-rest-spread": {
+                    "version": "6.26.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+                        "babel-runtime": "^6.26.0"
+                    }
+                },
+                "babel-plugin-transform-react-jsx": {
+                    "version": "6.24.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "babel-helper-builder-react-jsx": "^6.24.1",
+                        "babel-plugin-syntax-jsx": "^6.8.0",
+                        "babel-runtime": "^6.22.0"
+                    }
+                },
+                "babel-register": {
+                    "version": "6.26.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "babel-core": "^6.26.0",
+                        "babel-runtime": "^6.26.0",
+                        "core-js": "^2.5.0",
+                        "home-or-tmp": "^2.0.0",
+                        "lodash": "^4.17.4",
+                        "mkdirp": "^0.5.1",
+                        "source-map-support": "^0.4.15"
+                    },
+                    "dependencies": {
+                        "source-map": {
+                            "version": "0.5.7",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "source-map-support": {
+                            "version": "0.4.18",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "source-map": "^0.5.6"
+                            }
+                        }
+                    }
+                },
+                "babel-runtime": {
+                    "version": "6.26.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "core-js": "^2.4.0",
+                        "regenerator-runtime": "^0.11.0"
+                    }
+                },
+                "babel-template": {
+                    "version": "6.26.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "^6.26.0",
+                        "babel-traverse": "^6.26.0",
+                        "babel-types": "^6.26.0",
+                        "babylon": "^6.18.0",
+                        "lodash": "^4.17.4"
+                    }
+                },
+                "babel-traverse": {
+                    "version": "6.26.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "babel-code-frame": "^6.26.0",
+                        "babel-messages": "^6.23.0",
+                        "babel-runtime": "^6.26.0",
+                        "babel-types": "^6.26.0",
+                        "babylon": "^6.18.0",
+                        "debug": "^2.6.8",
+                        "globals": "^9.18.0",
+                        "invariant": "^2.2.2",
+                        "lodash": "^4.17.4"
+                    }
+                },
+                "babel-types": {
+                    "version": "6.26.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "babel-runtime": "^6.26.0",
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.4",
+                        "to-fast-properties": "^1.0.3"
+                    }
+                },
+                "babylon": {
+                    "version": "6.18.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "balanced-match": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "caller-callsite": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "callsites": "^2.0.0"
+                    }
+                },
+                "caller-path": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "caller-callsite": "^2.0.0"
+                    }
+                },
+                "callsites": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "cardinal": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansicolors": "~0.3.2",
+                        "redeyed": "~2.1.0"
+                    }
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "ci-info": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "cli-cursor": {
+                    "version": "2.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "restore-cursor": "^2.0.0"
+                    }
+                },
+                "cli-truncate": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "slice-ansi": "^1.0.0",
+                        "string-width": "^2.0.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "1.9.3",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "color-name": "1.1.3"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "convert-source-map": {
+                    "version": "1.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.1"
+                    }
+                },
+                "core-js": {
+                    "version": "2.6.5",
+                    "bundled": true,
+                    "dev": true
+                },
+                "csstype": {
+                    "version": "2.6.5",
+                    "bundled": true,
+                    "dev": true
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "detect-indent": {
+                    "version": "4.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "repeating": "^2.0.0"
+                    }
+                },
+                "diff": {
+                    "version": "4.0.1",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/diff/-/diff-4.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdiff%2F-%2Fdiff-4.0.1.tgz",
+                    "integrity": "sha1-DGZ8tGfru1zqfxTxNcwtuneAqP8=",
+                    "dev": true
+                },
+                "emoji-regex": {
+                    "version": "7.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true
+                },
+                "esprima": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "esutils": {
+                    "version": "2.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "events-to-array": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "globals": {
+                    "version": "9.18.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "has-ansi": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "home-or-tmp": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.1"
+                    }
+                },
+                "import-jsx": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "babel-core": "^6.25.0",
+                        "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+                        "babel-plugin-transform-object-rest-spread": "^6.23.0",
+                        "babel-plugin-transform-react-jsx": "^6.24.1",
+                        "caller-path": "^2.0.0",
+                        "resolve-from": "^3.0.0"
+                    }
+                },
+                "ink": {
+                    "version": "2.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@types/react": "^16.8.6",
+                        "arrify": "^1.0.1",
+                        "auto-bind": "^2.0.0",
+                        "chalk": "^2.4.1",
+                        "cli-cursor": "^2.1.0",
+                        "cli-truncate": "^1.1.0",
+                        "is-ci": "^2.0.0",
+                        "lodash.throttle": "^4.1.1",
+                        "log-update": "^3.0.0",
+                        "prop-types": "^15.6.2",
+                        "react-reconciler": "^0.20.0",
+                        "scheduler": "^0.13.2",
+                        "signal-exit": "^3.0.2",
+                        "slice-ansi": "^1.0.0",
+                        "string-length": "^2.0.0",
+                        "widest-line": "^2.0.0",
+                        "wrap-ansi": "^5.0.0",
+                        "yoga-layout-prebuilt": "^1.9.3"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "4.1.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "ansi-styles": {
+                            "version": "3.2.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "color-convert": "^1.9.0"
+                            }
+                        },
+                        "chalk": {
+                            "version": "2.4.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ansi-styles": "^3.2.1",
+                                "escape-string-regexp": "^1.0.5",
+                                "supports-color": "^5.3.0"
+                            }
+                        },
+                        "string-width": {
+                            "version": "3.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "emoji-regex": "^7.0.1",
+                                "is-fullwidth-code-point": "^2.0.0",
+                                "strip-ansi": "^5.1.0"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "5.2.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^4.1.0"
+                            }
+                        },
+                        "supports-color": {
+                            "version": "5.5.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "has-flag": "^3.0.0"
+                            }
+                        },
+                        "wrap-ansi": {
+                            "version": "5.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ansi-styles": "^3.2.0",
+                                "string-width": "^3.0.0",
+                                "strip-ansi": "^5.0.0"
+                            }
+                        }
+                    }
+                },
+                "invariant": {
+                    "version": "2.2.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "loose-envify": "^1.0.0"
+                    }
+                },
+                "is-ci": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ci-info": "^2.0.0"
+                    }
+                },
+                "is-finite": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "js-tokens": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "jsesc": {
+                    "version": "1.3.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "json5": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lodash": {
+                    "version": "4.17.14",
+                    "bundled": true,
+                    "dev": true
+                },
+                "lodash.throttle": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "log-update": {
+                    "version": "3.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-escapes": "^3.2.0",
+                        "cli-cursor": "^2.1.0",
+                        "wrap-ansi": "^5.0.0"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "4.1.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "ansi-styles": {
+                            "version": "3.2.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "color-convert": "^1.9.0"
+                            }
+                        },
+                        "string-width": {
+                            "version": "3.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "emoji-regex": "^7.0.1",
+                                "is-fullwidth-code-point": "^2.0.0",
+                                "strip-ansi": "^5.1.0"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "5.2.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^4.1.0"
+                            }
+                        },
+                        "wrap-ansi": {
+                            "version": "5.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ansi-styles": "^3.2.0",
+                                "string-width": "^3.0.0",
+                                "strip-ansi": "^5.0.0"
+                            }
+                        }
+                    }
+                },
+                "loose-envify": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "js-tokens": "^3.0.0 || ^4.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
+                "minipass": {
+                    "version": "2.3.5",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "^5.1.2",
+                        "yallist": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "yallist": {
+                            "version": "3.0.3",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
+                    },
+                    "dependencies": {
+                        "minimist": {
+                            "version": "0.0.8",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "nyc": {
+                    "version": "14.1.1",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/nyc/-/nyc-14.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fnyc%2F-%2Fnyc-14.1.1.tgz",
+                    "integrity": "sha1-FR1kpqn59ZCKG3MjOTHkoKMHXus=",
+                    "dev": true,
+                    "requires": {
+                        "archy": "^1.0.0",
+                        "caching-transform": "^3.0.2",
+                        "convert-source-map": "^1.6.0",
+                        "cp-file": "^6.2.0",
+                        "find-cache-dir": "^2.1.0",
+                        "find-up": "^3.0.0",
+                        "foreground-child": "^1.5.6",
+                        "glob": "^7.1.3",
+                        "istanbul-lib-coverage": "^2.0.5",
+                        "istanbul-lib-hook": "^2.0.7",
+                        "istanbul-lib-instrument": "^3.3.0",
+                        "istanbul-lib-report": "^2.0.8",
+                        "istanbul-lib-source-maps": "^3.0.6",
+                        "istanbul-reports": "^2.2.4",
+                        "js-yaml": "^3.13.1",
+                        "make-dir": "^2.1.0",
+                        "merge-source-map": "^1.1.0",
+                        "resolve-from": "^4.0.0",
+                        "rimraf": "^2.6.3",
+                        "signal-exit": "^3.0.2",
+                        "spawn-wrap": "^1.4.2",
+                        "test-exclude": "^5.2.3",
+                        "uuid": "^3.3.2",
+                        "yargs": "^13.2.2",
+                        "yargs-parser": "^13.0.0"
+                    },
+                    "dependencies": {
+                        "resolve-from": {
+                            "version": "4.0.0",
+                            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/resolve-from/-/resolve-from-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fresolve-from%2F-%2Fresolve-from-4.0.0.tgz",
+                            "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
+                            "dev": true
+                        }
+                    }
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "onetime": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "mimic-fn": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "mimic-fn": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "dev": true
+                        }
+                    }
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "private": {
+                    "version": "0.1.8",
+                    "bundled": true,
+                    "dev": true
+                },
+                "prop-types": {
+                    "version": "15.7.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "loose-envify": "^1.4.0",
+                        "object-assign": "^4.1.1",
+                        "react-is": "^16.8.1"
+                    }
+                },
+                "punycode": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "react": {
+                    "version": "16.8.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "loose-envify": "^1.1.0",
+                        "object-assign": "^4.1.1",
+                        "prop-types": "^15.6.2",
+                        "scheduler": "^0.13.6"
+                    }
+                },
+                "react-is": {
+                    "version": "16.8.6",
+                    "bundled": true,
+                    "dev": true
+                },
+                "react-reconciler": {
+                    "version": "0.20.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "loose-envify": "^1.1.0",
+                        "object-assign": "^4.1.1",
+                        "prop-types": "^15.6.2",
+                        "scheduler": "^0.13.6"
+                    }
+                },
+                "redeyed": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "esprima": "~4.0.0"
+                    }
+                },
+                "regenerator-runtime": {
+                    "version": "0.11.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "repeating": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-finite": "^1.0.0"
+                    }
+                },
+                "resolve-from": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "restore-cursor": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "onetime": "^2.0.0",
+                        "signal-exit": "^3.0.2"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "scheduler": {
+                    "version": "0.13.6",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "loose-envify": "^1.1.0",
+                        "object-assign": "^4.1.1"
+                    }
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "slash": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "slice-ansi": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0"
+                    }
+                },
+                "string-length": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "astral-regex": "^1.0.0",
+                        "strip-ansi": "^4.0.0"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "3.0.0",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "tap-parser": {
+                    "version": "9.3.2",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "events-to-array": "^1.0.1",
+                        "minipass": "^2.2.0",
+                        "tap-yaml": "^1.0.0"
+                    }
+                },
+                "tap-yaml": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "yaml": "^1.5.0"
+                    }
+                },
+                "to-fast-properties": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "treport": {
+                    "version": "0.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "cardinal": "^2.1.1",
+                        "chalk": "^2.4.2",
+                        "import-jsx": "^2.0.0",
+                        "ink": "^2.1.1",
+                        "ms": "^2.1.1",
+                        "react": "^16.8.6",
+                        "string-length": "^2.0.0",
+                        "tap-parser": "^9.3.2",
+                        "unicode-length": "^2.0.1"
+                    },
+                    "dependencies": {
+                        "ansi-styles": {
+                            "version": "3.2.1",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "color-convert": "^1.9.0"
+                            }
+                        },
+                        "chalk": {
+                            "version": "2.4.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "ansi-styles": "^3.2.1",
+                                "escape-string-regexp": "^1.0.5",
+                                "supports-color": "^5.3.0"
+                            }
+                        },
+                        "ms": {
+                            "version": "2.1.2",
+                            "bundled": true,
+                            "dev": true
+                        },
+                        "supports-color": {
+                            "version": "5.5.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "has-flag": "^3.0.0"
+                            }
+                        },
+                        "unicode-length": {
+                            "version": "2.0.2",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "punycode": "^2.0.0",
+                                "strip-ansi": "^3.0.1"
+                            }
+                        }
+                    }
+                },
+                "trim-right": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "uuid": {
+                    "version": "3.3.3",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/uuid/-/uuid-3.3.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fuuid%2F-%2Fuuid-3.3.3.tgz",
+                    "integrity": "sha1-RWjwIW54dg7h2/Ok0s9T4iQRKGY=",
+                    "dev": true
+                },
+                "widest-line": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^2.1.1"
+                    }
+                },
+                "yaml": {
+                    "version": "1.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "@babel/runtime": "^7.4.5"
+                    }
+                },
+                "yoga-layout-prebuilt": {
+                    "version": "1.9.3",
+                    "bundled": true,
+                    "dev": true
+                }
+            }
+        },
+        "tap-junit": {
+            "version": "2.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/tap-junit/-/tap-junit-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftap-junit%2F-%2Ftap-junit-2.0.0.tgz",
+            "integrity": "sha1-IF1QSle1JPGB9echzR49nd/ijdM=",
+            "dev": true,
+            "requires": {
+                "duplexer2": "0.1.4",
+                "fs-extra": "6.0.0",
+                "minimist": "1.2.0",
+                "tap-out": "3.0.0",
+                "through2": "2.0.3",
+                "xmlbuilder": "10.0.0"
+            }
+        },
+        "tap-mocha-reporter": {
+            "version": "4.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/tap-mocha-reporter/-/tap-mocha-reporter-4.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftap-mocha-reporter%2F-%2Ftap-mocha-reporter-4.0.1.tgz",
+            "integrity": "sha1-9hMinELC5bXwlvLwIuiHJMk4CxA=",
+            "dev": true,
+            "requires": {
+                "color-support": "^1.1.0",
+                "debug": "^2.1.3",
+                "diff": "^1.3.2",
+                "escape-string-regexp": "^1.0.3",
+                "glob": "^7.0.5",
+                "readable-stream": "^2.1.5",
+                "tap-parser": "^8.0.0",
+                "tap-yaml": "0 || 1",
+                "unicode-length": "^1.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/debug/-/debug-2.6.9.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdebug%2F-%2Fdebug-2.6.9.tgz",
+                    "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "diff": {
+                    "version": "1.4.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/diff/-/diff-1.4.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdiff%2F-%2Fdiff-1.4.0.tgz",
+                    "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/ms/-/ms-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fms%2F-%2Fms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "tap-out": {
+            "version": "3.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/tap-out/-/tap-out-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftap-out%2F-%2Ftap-out-3.0.0.tgz",
+            "integrity": "sha1-Lt2GSYyxwNfzMpPVcX+aRNk5GG0=",
+            "dev": true,
+            "requires": {
+                "re-emitter": "1.1.3",
+                "readable-stream": "2.2.9",
+                "split": "1.0.0",
+                "trim": "0.0.1"
+            },
+            "dependencies": {
+                "process-nextick-args": {
+                    "version": "1.0.7",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/process-nextick-args/-/process-nextick-args-1.0.7.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fprocess-nextick-args%2F-%2Fprocess-nextick-args-1.0.7.tgz",
+                    "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.2.9",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/readable-stream/-/readable-stream-2.2.9.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Freadable-stream%2F-%2Freadable-stream-2.2.9.tgz",
+                    "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+                    "dev": true,
+                    "requires": {
+                        "buffer-shims": "~1.0.0",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~1.0.0",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/safe-buffer/-/safe-buffer-5.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fsafe-buffer%2F-%2Fsafe-buffer-5.1.2.tgz",
+                    "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+                    "dev": true
+                },
+                "string_decoder": {
+                    "version": "1.0.3",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/string_decoder/-/string_decoder-1.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstring_decoder%2F-%2Fstring_decoder-1.0.3.tgz",
+                    "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
+            }
+        },
+        "tap-parser": {
+            "version": "8.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/tap-parser/-/tap-parser-8.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftap-parser%2F-%2Ftap-parser-8.1.0.tgz",
+            "integrity": "sha1-av9SIcD+mzl1fWDq/ExDbDqRiPw=",
+            "dev": true,
+            "requires": {
+                "events-to-array": "^1.0.1",
+                "minipass": "^2.2.0",
+                "tap-yaml": "0 || 1"
+            }
+        },
+        "tap-yaml": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/tap-yaml/-/tap-yaml-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftap-yaml%2F-%2Ftap-yaml-1.0.0.tgz",
+            "integrity": "sha1-TjFEOlSJ4Fyou7PjbO9xtd7GljU=",
+            "dev": true,
+            "requires": {
+                "yaml": "^1.5.0"
+            }
+        },
+        "tcompare": {
+            "version": "2.3.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/tcompare/-/tcompare-2.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftcompare%2F-%2Ftcompare-2.3.0.tgz",
+            "integrity": "sha1-T1q1akqySO4rjMSW4GddR7QmT94=",
+            "dev": true
+        },
+        "test-exclude": {
+            "version": "5.2.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/test-exclude/-/test-exclude-5.2.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftest-exclude%2F-%2Ftest-exclude-5.2.3.tgz",
+            "integrity": "sha1-w9Ph4xHrfuQF4JLawQrv0JCR6sA=",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3",
+                "minimatch": "^3.0.4",
+                "read-pkg-up": "^4.0.0",
+                "require-main-filename": "^2.0.0"
+            }
+        },
+        "text-table": {
+            "version": "0.2.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/text-table/-/text-table-0.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftext-table%2F-%2Ftext-table-0.2.0.tgz",
+            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+            "dev": true
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/through/-/through-2.3.8.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fthrough%2F-%2Fthrough-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
+        "through2": {
+            "version": "2.0.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/through2/-/through2-2.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fthrough2%2F-%2Fthrough2-2.0.3.tgz",
+            "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
+            }
+        },
+        "timed-out": {
+            "version": "4.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/timed-out/-/timed-out-4.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftimed-out%2F-%2Ftimed-out-4.0.1.tgz",
+            "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+        },
+        "tmp": {
+            "version": "0.0.33",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/tmp/-/tmp-0.0.33.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftmp%2F-%2Ftmp-0.0.33.tgz",
+            "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+            "dev": true,
+            "requires": {
+                "os-tmpdir": "~1.0.2"
+            }
+        },
+        "to-fast-properties": {
+            "version": "2.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/to-fast-properties/-/to-fast-properties-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fto-fast-properties%2F-%2Fto-fast-properties-2.0.0.tgz",
+            "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+            "dev": true
+        },
+        "to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/to-regex-range/-/to-regex-range-5.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fto-regex-range%2F-%2Fto-regex-range-5.0.1.tgz",
+            "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
+            "dev": true,
+            "requires": {
+                "is-number": "^7.0.0"
+            }
+        },
+        "tough-cookie": {
+            "version": "2.4.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/tough-cookie/-/tough-cookie-2.4.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftough-cookie%2F-%2Ftough-cookie-2.4.3.tgz",
+            "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
+            "requires": {
+                "psl": "^1.1.24",
+                "punycode": "^1.4.1"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/punycode/-/punycode-1.4.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpunycode%2F-%2Fpunycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+                }
+            }
+        },
+        "trim": {
+            "version": "0.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/trim/-/trim-0.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftrim%2F-%2Ftrim-0.0.1.tgz",
+            "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+            "dev": true
+        },
+        "trim-right": {
+            "version": "1.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/trim-right/-/trim-right-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftrim-right%2F-%2Ftrim-right-1.0.1.tgz",
+            "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+            "dev": true
+        },
+        "trivial-deferred": {
+            "version": "1.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/trivial-deferred/-/trivial-deferred-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftrivial-deferred%2F-%2Ftrivial-deferred-1.0.1.tgz",
+            "integrity": "sha1-N21NKdlR1jaKb3oK6FwvTV4GWPM=",
+            "dev": true
+        },
+        "ts-node": {
+            "version": "8.3.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/ts-node/-/ts-node-8.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fts-node%2F-%2Fts-node-8.3.0.tgz",
+            "integrity": "sha1-5AWWGEETcZJKH7XzsSWRXzJO+1c=",
+            "dev": true,
+            "requires": {
+                "arg": "^4.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "source-map-support": "^0.5.6",
+                "yn": "^3.0.0"
+            },
+            "dependencies": {
+                "diff": {
+                    "version": "4.0.1",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/diff/-/diff-4.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdiff%2F-%2Fdiff-4.0.1.tgz",
+                    "integrity": "sha1-DGZ8tGfru1zqfxTxNcwtuneAqP8=",
+                    "dev": true
+                }
+            }
+        },
+        "tslib": {
+            "version": "1.10.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/tslib/-/tslib-1.10.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftslib%2F-%2Ftslib-1.10.0.tgz",
+            "integrity": "sha1-w8GflZc/sKYpc/sJ2Q2WHuQ+XIo="
+        },
+        "tunnel-agent": {
+            "version": "0.6.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/tunnel-agent/-/tunnel-agent-0.6.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftunnel-agent%2F-%2Ftunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/tweetnacl/-/tweetnacl-0.14.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftweetnacl%2F-%2Ftweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+        },
+        "type-check": {
+            "version": "0.3.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/type-check/-/type-check-0.3.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftype-check%2F-%2Ftype-check-0.3.2.tgz",
+            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "~1.1.2"
+            }
+        },
+        "type-detect": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/type-detect/-/type-detect-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftype-detect%2F-%2Ftype-detect-1.0.0.tgz",
+            "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+            "dev": true
+        },
+        "typedarray-to-buffer": {
+            "version": "3.1.5",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftypedarray-to-buffer%2F-%2Ftypedarray-to-buffer-3.1.5.tgz",
+            "integrity": "sha1-qX7nqf9CaRufeD/xvFES/j/KkIA=",
+            "dev": true,
+            "requires": {
+                "is-typedarray": "^1.0.0"
+            }
+        },
+        "typescript": {
+            "version": "3.6.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/typescript/-/typescript-3.6.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Ftypescript%2F-%2Ftypescript-3.6.2.tgz",
+            "integrity": "sha1-EFsPGTQRnd5UOsjrca86kQCe/lQ=",
+            "dev": true
+        },
+        "uglify-js": {
+            "version": "3.6.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/uglify-js/-/uglify-js-3.6.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fuglify-js%2F-%2Fuglify-js-3.6.0.tgz",
+            "integrity": "sha1-cEaBNFxTqLIHn7bOwpSwXq0kL/U=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "commander": "~2.20.0",
+                "source-map": "~0.6.1"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.20.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/commander/-/commander-2.20.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcommander%2F-%2Fcommander-2.20.0.tgz",
+                    "integrity": "sha1-1YuytcHuj4ew00ACfp6U4iLFpCI=",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "underscore": {
+            "version": "1.9.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/underscore/-/underscore-1.9.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Funderscore%2F-%2Funderscore-1.9.1.tgz",
+            "integrity": "sha1-BtzjSg5op7q8KbNluOdLiSUgOWE="
+        },
+        "unexpected": {
+            "version": "10.40.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/unexpected/-/unexpected-10.40.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Funexpected%2F-%2Funexpected-10.40.2.tgz",
+            "integrity": "sha1-G7B/67stm5ABw4P9a9nbvnQOPUk=",
+            "dev": true,
+            "requires": {
+                "array-changes": "3.0.1",
+                "array-changes-async": "3.0.1",
+                "babel-runtime": "6.26.0",
+                "detect-indent": "3.0.1",
+                "diff": "1.1.0",
+                "greedy-interval-packer": "1.2.0",
+                "leven": "2.1.0",
+                "magicpen": "5.12.0",
+                "unexpected-bluebird": "2.9.34-longstack2"
+            },
+            "dependencies": {
+                "diff": {
+                    "version": "1.1.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/diff/-/diff-1.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fdiff%2F-%2Fdiff-1.1.0.tgz",
+                    "integrity": "sha1-eYpJOBqkZBUem08Ob/Kwmooa0j8=",
+                    "dev": true
+                }
+            }
+        },
+        "unexpected-bluebird": {
+            "version": "2.9.34-longstack2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/unexpected-bluebird/-/unexpected-bluebird-2.9.34-longstack2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Funexpected-bluebird%2F-%2Funexpected-bluebird-2.9.34-longstack2.tgz",
+            "integrity": "sha1-SaysdTsFVt7WAlIQ7pYYIwfSssk=",
+            "dev": true
+        },
+        "unicode-length": {
+            "version": "1.0.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/unicode-length/-/unicode-length-1.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Funicode-length%2F-%2Funicode-length-1.0.3.tgz",
+            "integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
+            "dev": true,
+            "requires": {
+                "punycode": "^1.3.2",
+                "strip-ansi": "^3.0.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/ansi-regex/-/ansi-regex-2.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-regex%2F-%2Fansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/punycode/-/punycode-1.4.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fpunycode%2F-%2Fpunycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/strip-ansi/-/strip-ansi-3.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstrip-ansi%2F-%2Fstrip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "universalify": {
+            "version": "0.1.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/universalify/-/universalify-0.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Funiversalify%2F-%2Funiversalify-0.1.2.tgz",
+            "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
+            "dev": true
+        },
+        "uri-js": {
+            "version": "4.2.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/uri-js/-/uri-js-4.2.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Furi-js%2F-%2Furi-js-4.2.2.tgz",
+            "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
+            "requires": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "url-join": {
+            "version": "4.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/url-join/-/url-join-4.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Furl-join%2F-%2Furl-join-4.0.1.tgz",
+            "integrity": "sha1-tkLiGiZGgI/6F4xMX9o5hE4Szec="
+        },
+        "url-parse-lax": {
+            "version": "3.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/url-parse-lax/-/url-parse-lax-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Furl-parse-lax%2F-%2Furl-parse-lax-3.0.0.tgz",
+            "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+            "requires": {
+                "prepend-http": "^2.0.0"
+            }
+        },
+        "url-to-options": {
+            "version": "1.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/url-to-options/-/url-to-options-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Furl-to-options%2F-%2Furl-to-options-1.0.1.tgz",
+            "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/util-deprecate/-/util-deprecate-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Futil-deprecate%2F-%2Futil-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        },
+        "uuid": {
+            "version": "2.0.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/uuid/-/uuid-2.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fuuid%2F-%2Fuuid-2.0.3.tgz",
+            "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+        },
+        "v8-compile-cache": {
+            "version": "2.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fv8-compile-cache%2F-%2Fv8-compile-cache-2.1.0.tgz",
+            "integrity": "sha1-4U3jezGm0ZT1aQ1n78Tn9vxqsw4=",
+            "dev": true
+        },
+        "validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fvalidate-npm-package-license%2F-%2Fvalidate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
+            "dev": true,
+            "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "verror": {
+            "version": "1.10.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/verror/-/verror-1.10.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fverror%2F-%2Fverror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "requires": {
+                "assert-plus": "^1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "^1.2.0"
+            }
+        },
+        "vlq": {
+            "version": "0.2.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/vlq/-/vlq-0.2.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fvlq%2F-%2Fvlq-0.2.3.tgz",
+            "integrity": "sha1-jz5DKM9jsVQMDWfhsneDhviXWyY=",
+            "dev": true
+        },
+        "which": {
+            "version": "1.3.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/which/-/which-1.3.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwhich%2F-%2Fwhich-1.3.1.tgz",
+            "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+            "dev": true,
+            "requires": {
+                "isexe": "^2.0.0"
+            }
+        },
+        "which-module": {
+            "version": "2.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/which-module/-/which-module-2.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwhich-module%2F-%2Fwhich-module-2.0.0.tgz",
+            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+            "dev": true
+        },
+        "wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/wordwrap/-/wordwrap-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwordwrap%2F-%2Fwordwrap-1.0.0.tgz",
+            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+            "dev": true
+        },
+        "wrap-ansi": {
+            "version": "2.1.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/wrap-ansi/-/wrap-ansi-2.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwrap-ansi%2F-%2Fwrap-ansi-2.1.0.tgz",
+            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "dev": true,
+            "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/ansi-regex/-/ansi-regex-2.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-regex%2F-%2Fansi-regex-2.1.1.tgz",
+                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fis-fullwidth-code-point%2F-%2Fis-fullwidth-code-point-1.0.0.tgz",
+                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "dev": true,
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/string-width/-/string-width-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstring-width%2F-%2Fstring-width-1.0.2.tgz",
+                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
+                    "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/strip-ansi/-/strip-ansi-3.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstrip-ansi%2F-%2Fstrip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/wrappy/-/wrappy-1.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwrappy%2F-%2Fwrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "write": {
+            "version": "1.0.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/write/-/write-1.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwrite%2F-%2Fwrite-1.0.3.tgz",
+            "integrity": "sha1-CADhRSO5I6OH5BUSPIZWFqrg9cM=",
+            "dev": true,
+            "requires": {
+                "mkdirp": "^0.5.1"
+            }
+        },
+        "write-file-atomic": {
+            "version": "3.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/write-file-atomic/-/write-file-atomic-3.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwrite-file-atomic%2F-%2Fwrite-file-atomic-3.0.0.tgz",
+            "integrity": "sha1-G2Tbv3fLWP0JBWlj1j5iZnq0+yE=",
+            "dev": true,
+            "requires": {
+                "imurmurhash": "^0.1.4",
+                "is-typedarray": "^1.0.0",
+                "signal-exit": "^3.0.2",
+                "typedarray-to-buffer": "^3.1.5"
+            }
+        },
+        "ws": {
+            "version": "7.1.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/ws/-/ws-7.1.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fws%2F-%2Fws-7.1.2.tgz",
+            "integrity": "sha1-xnLRYp3ouyepaZ61mb5Hru7dj3M=",
+            "requires": {
+                "async-limiter": "^1.0.0"
+            }
+        },
+        "xml": {
+            "version": "1.0.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/xml/-/xml-1.0.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fxml%2F-%2Fxml-1.0.1.tgz",
+            "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+            "dev": true
+        },
+        "xmlbuilder": {
+            "version": "10.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/xmlbuilder/-/xmlbuilder-10.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fxmlbuilder%2F-%2Fxmlbuilder-10.0.0.tgz",
+            "integrity": "sha1-xk5S+K4Jf+X9RtHDitqt4HHuG1U=",
+            "dev": true
+        },
+        "xtend": {
+            "version": "4.0.2",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/xtend/-/xtend-4.0.2.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fxtend%2F-%2Fxtend-4.0.2.tgz",
+            "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
+            "dev": true
+        },
+        "y18n": {
+            "version": "4.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/y18n/-/y18n-4.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fy18n%2F-%2Fy18n-4.0.0.tgz",
+            "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
+            "dev": true
+        },
+        "yallist": {
+            "version": "3.0.3",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/yallist/-/yallist-3.0.3.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fyallist%2F-%2Fyallist-3.0.3.tgz",
+            "integrity": "sha1-tLBJ4xS+VF486AIjbWzSLNkcPek="
+        },
+        "yaml": {
+            "version": "1.6.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/yaml/-/yaml-1.6.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fyaml%2F-%2Fyaml-1.6.0.tgz",
+            "integrity": "sha1-2KmFz7Jght1z+Rxjf25ryQn93Tw=",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.4.5"
+            }
+        },
+        "yapool": {
+            "version": "1.0.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/yapool/-/yapool-1.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fyapool%2F-%2Fyapool-1.0.0.tgz",
+            "integrity": "sha1-9pPymjFbUNmp2iZGp6ZkXJaYW2o=",
+            "dev": true
+        },
+        "yargs": {
+            "version": "13.3.0",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/yargs/-/yargs-13.3.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fyargs%2F-%2Fyargs-13.3.0.tgz",
+            "integrity": "sha1-TGV6VeB+Xyz5R/ijZlZ8BKDe3IM=",
+            "dev": true,
+            "requires": {
+                "cliui": "^5.0.0",
+                "find-up": "^3.0.0",
+                "get-caller-file": "^2.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^2.0.0",
+                "set-blocking": "^2.0.0",
+                "string-width": "^3.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^4.0.0",
+                "yargs-parser": "^13.1.1"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.1.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/ansi-regex/-/ansi-regex-4.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fansi-regex%2F-%2Fansi-regex-4.1.0.tgz",
+                    "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+                    "dev": true
+                },
+                "cliui": {
+                    "version": "5.0.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/cliui/-/cliui-5.0.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fcliui%2F-%2Fcliui-5.0.0.tgz",
+                    "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
+                    "dev": true,
+                    "requires": {
+                        "string-width": "^3.1.0",
+                        "strip-ansi": "^5.2.0",
+                        "wrap-ansi": "^5.1.0"
+                    }
+                },
+                "string-width": {
+                    "version": "3.1.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/string-width/-/string-width-3.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstring-width%2F-%2Fstring-width-3.1.0.tgz",
+                    "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "5.2.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/strip-ansi/-/strip-ansi-5.2.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fstrip-ansi%2F-%2Fstrip-ansi-5.2.0.tgz",
+                    "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^4.1.0"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "5.1.0",
+                    "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/wrap-ansi/-/wrap-ansi-5.1.0.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fwrap-ansi%2F-%2Fwrap-ansi-5.1.0.tgz",
+                    "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.0",
+                        "string-width": "^3.0.0",
+                        "strip-ansi": "^5.0.0"
+                    }
+                }
+            }
+        },
+        "yargs-parser": {
+            "version": "13.1.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/yargs-parser/-/yargs-parser-13.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fyargs-parser%2F-%2Fyargs-parser-13.1.1.tgz",
+            "integrity": "sha1-0mBYUyqgbTZf4JH2ofwGsvfl7KA=",
+            "dev": true,
+            "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+            }
+        },
+        "yn": {
+            "version": "3.1.1",
+            "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/hyc-hdm-npm-virtual/yn/-/yn-3.1.1.tgz?dl=https%3A%2F%2Fregistry.npmjs.org%2Fyn%2F-%2Fyn-3.1.1.tgz",
+            "integrity": "sha1-HodAGgnXZ8HV6rJqbkwYUYLS61A=",
+            "dev": true
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -6,27 +6,27 @@
     "description": "Node.js rest client for ICAM.",
     "dependencies": {
         "https-proxy-agent": "^2.2.1",
-        "kubernetes-client": "^3.16.0",
+        "kubernetes-client": "^8.3.4",
         "log4js": "^0.6.38",
         "properties": "^1.2.1",
         "request": "^2.72.0",
         "uuid": "^2.0.2"
     },
     "devDependencies": {
+        "async": "^0.9.0",
         "chai": "^3.5.0",
-        "eslint": "^3.19.0",
+        "coveralls": "^3.0.6",
+        "eslint": "^6.3.0",
         "eslint-config-strongloop": "^2.1.0",
-        "should": "^9.0.0",
-        "should-http": "0.0.4",
-        "unexpected": "^10.13.3",
+        "intercept-stdout": "~0.1.2",
         "mocha": "^3.2.0",
         "mocha-junit-reporter": "^1.12.0",
-        "async": "^0.9.0",
-        "coveralls": "^2.11.2",
-        "intercept-stdout": "~0.1.2",
         "nyc": "^11.0.2",
-        "tap": "12.x",
-        "tap-junit": "2.0.0"
+        "should": "^9.0.0",
+        "should-http": "0.0.4",
+        "tap": "^14.6.1",
+        "tap-junit": "2.0.0",
+        "unexpected": "^10.13.3"
     },
     "scripts": {
         "test": "./node_modules/.bin/nyc --cache ./node_modules/.bin/tap --timeout=120 tests/*tests.js | tap-junit --output . --name jenkins-test-results",


### PR DESCRIPTION
Updating dependencies that required a version of `js-yaml` with a code execution vulnerability.

See https://github.com/nodeca/js-yaml/pull/480 for details about the fix to `js-yaml`.